### PR TITLE
BXMSPROD-912 improved to allow multiple jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Github Action Build Chain
 
 ## How to add it to your project(s)
+
 // TODO by https://issues.redhat.com/browse/BXMSPROD-913
+
 ## Docker build
+
 You can build the `github-action-build-chain` image on your just executing
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # Github Action Build Chain
 
+## How to add it to your project(s)
+// TODO by https://issues.redhat.com/browse/BXMSPROD-913
+## Docker build
+You can build the `github-action-build-chain` image on your just executing
+
+```
+docker build .
+```
+
+In case you want to build it for a different openjdk version you just specify a `--build-arg OPENJDK_VERSION` argument
+
+```
+docker build --build-arg OPENJDK_VERSION=11 .
+```
+
 ## Testing
 
-### Unitary testing
+### Unit testing
 
 - **TEST_GITHUB_TOKEN** env variable is needed
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Github action chain"
-author: "Enrique Mingorance Cano"
+author: "Enrique Mingorance Cano <emingora@redhat.com>"
 description: "GitHub action to define action chains"
 inputs:
   parent-dependencies:
@@ -7,6 +7,12 @@ inputs:
     required: false
   child-dependencies:
     description: "the list of child project dependencies separated by comma. Something like appformer,kiegroup/droolsjbpm-build-bootstrap,drools"
+    required: false
+  build-command:
+    description: "the list of commands as string split by | to run"
+    required: true
+  build-command-upstream:
+    description: "the list of commands as string split by | to run in case the project is upstream built"
     required: false
 runs:
   using: "docker"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "locktt": "locktt",
     "lint": "eslint .",
     "prettier": "prettier -l src/** test/**/*.js",
+    "prettier-write": "prettier --write .",
     "lint-final": "npm run prettier && npm run lint",
     "prepublish": "npm run lint && npm run test"
   },

--- a/src/lib/build-chain-flow-helper.js
+++ b/src/lib/build-chain-flow-helper.js
@@ -8,6 +8,7 @@ const {
 } = require("./git");
 const { logger, dependenciesToObject } = require("./common");
 const { getYamlFileContent } = require("./fs-helper");
+var assert = require("assert");
 
 async function checkoutDependencies(context, dependencies) {
   for (const dependencyKey of Object.keys(dependencies)) {
@@ -134,22 +135,18 @@ function getDir(project) {
   return project.replace(/ |-/g, "_");
 }
 
-function readWorkflowInformation(workflowFilePath, dir = ".") {
+function readWorkflowInformation(triggeringJobName, workflowFilePath, dir = ".") {
   const filePath = path.join(dir, workflowFilePath);
   if (!fs.existsSync(filePath)) {
     logger.warn(`file ${filePath} does not exist`);
     return undefined;
   }
-  return parseWorkflowInformation(getYamlFileContent(filePath));
+  return parseWorkflowInformation(triggeringJobName, getYamlFileContent(filePath));
 }
 
-function parseWorkflowInformation(workflowData) {
-  const buildChainKey = Object.keys(workflowData.jobs).find(key =>
-    workflowData.jobs[key].steps.find(
-      step => step.uses && step.uses.includes("github-action-build-chain")
-    )
-  );
-  const buildChainStep = workflowData.jobs[buildChainKey].steps.find(
+function parseWorkflowInformation(jobName, workflowData) {
+  assert(workflowData.jobs[jobName], `The job id '${jobName}' does not exist`);  
+  const buildChainStep = workflowData.jobs[jobName].steps.find(
     step => step.uses && step.uses.includes("github-action-build-chain")
   );
   return {

--- a/src/lib/build-chain-flow-helper.js
+++ b/src/lib/build-chain-flow-helper.js
@@ -135,17 +135,24 @@ function getDir(project) {
   return project.replace(/ |-/g, "_");
 }
 
-function readWorkflowInformation(triggeringJobName, workflowFilePath, dir = ".") {
+function readWorkflowInformation(
+  triggeringJobName,
+  workflowFilePath,
+  dir = "."
+) {
   const filePath = path.join(dir, workflowFilePath);
   if (!fs.existsSync(filePath)) {
     logger.warn(`file ${filePath} does not exist`);
     return undefined;
   }
-  return parseWorkflowInformation(triggeringJobName, getYamlFileContent(filePath));
+  return parseWorkflowInformation(
+    triggeringJobName,
+    getYamlFileContent(filePath)
+  );
 }
 
 function parseWorkflowInformation(jobName, workflowData) {
-  assert(workflowData.jobs[jobName], `The job id '${jobName}' does not exist`);  
+  assert(workflowData.jobs[jobName], `The job id '${jobName}' does not exist`);
   const buildChainStep = workflowData.jobs[jobName].steps.find(
     step => step.uses && step.uses.includes("github-action-build-chain")
   );

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -8,6 +8,7 @@ const { execute } = require("./command");
 
 async function start(context) {
   const workflowInformation = readWorkflowInformation(
+    context.config.github.jobName,
     context.config.github.workflow
   );
   await treatParents(
@@ -38,6 +39,7 @@ async function treatParents(
       ).filter(a => a !== null && a !== "")) {
         const dir = getDir(parentProject);
         const parentWorkflowInformation = readWorkflowInformation(
+          context.config.github.jobName,
           context.config.github.workflow,
           dir
         );

--- a/test/build-chain-flow-helper.test.js
+++ b/test/build-chain-flow-helper.test.js
@@ -14,6 +14,7 @@ const {
 test("parseWorkflowInformation", () => {
   // Act
   const buildChainInformation = readWorkflowInformation(
+    "build-chain",
     "flow.yaml",
     "test/resources"
   );

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -8,7 +8,7 @@ jest.mock("../src/lib/build-chain-flow-helper");
 
 test("treatParents", async () => {
   // Arrange
-  const context = { config: { github: { workflow: "main.yaml" } } };
+  const context = { config: { github: { jobName: "job-id", workflow: "main.yaml" } } };
   const workflowInformation = {
     id: "build-chain",
     name: "Build Chain",
@@ -31,5 +31,5 @@ test("treatParents", async () => {
   // Assert
   expect(checkoutDependencies).toHaveBeenCalledWith(context, { projectD: {} });
   expect(getDir).toHaveBeenCalledWith("projectD");
-  expect(readWorkflowInformation).toHaveBeenCalledWith("main.yaml", undefined);
+  expect(readWorkflowInformation).toHaveBeenCalledWith("job-id", "main.yaml", undefined);
 });

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -8,7 +8,9 @@ jest.mock("../src/lib/build-chain-flow-helper");
 
 test("treatParents", async () => {
   // Arrange
-  const context = { config: { github: { jobName: "job-id", workflow: "main.yaml" } } };
+  const context = {
+    config: { github: { jobName: "job-id", workflow: "main.yaml" } }
+  };
   const workflowInformation = {
     id: "build-chain",
     name: "Build Chain",
@@ -31,5 +33,9 @@ test("treatParents", async () => {
   // Assert
   expect(checkoutDependencies).toHaveBeenCalledWith(context, { projectD: {} });
   expect(getDir).toHaveBeenCalledWith("projectD");
-  expect(readWorkflowInformation).toHaveBeenCalledWith("job-id", "main.yaml", undefined);
+  expect(readWorkflowInformation).toHaveBeenCalledWith(
+    "job-id",
+    "main.yaml",
+    undefined
+  );
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-912
we are force to duplicate jobs because github actions does not allow `matrix` expressions on `uses` like `uses: kiegroup/github-action-build-chain@${{ matrix.openjdk-version }}`. It's not possible either to use `inputs` on `runs.image` from `actions.yml` file (from tool definition). It would good to have something `image: "docker://ginxo/github-action-build-chain:${{ inputs.buildchain-version }}"` but it's not possible.
I already filled in a ticket to [github action feedback support ](https://support.github.com/contact/feedback?contact%5Bcategory%5D=actions)
https://github.community/t/using-strategy-matrix-values-in-the-specification-of-actions-to-be-used-in-a-workflow/16706