### PR TITLE
BXMSPROD-927 it's possible to define different target group for depencies

### DIFF
--- a/src/lib/build-chain-flow-helper.js
+++ b/src/lib/build-chain-flow-helper.js
@@ -20,6 +20,7 @@ async function checkouProject(context, project, dependencyInformation) {
   const dir = getDir(project);
   const checkoutInfo = await getCheckoutInfo(
     context,
+    dependencyInformation.group,
     project,
     dependencyInformation.mapping
   );
@@ -31,17 +32,17 @@ async function checkouProject(context, project, dependencyInformation) {
 
   if (checkoutInfo.merge) {
     logger.info(
-      `Merging ${context.config.github.serverUrl}/${context.config.github.group}/${project}:${context.config.github.targetBranch} into ${context.config.github.serverUrl}/${checkoutInfo.group}/${project}:${checkoutInfo.branch}`
+      `Merging ${context.config.github.serverUrl}/${dependencyInformation.group}/${project}:${context.config.github.targetBranch} into ${context.config.github.serverUrl}/${checkoutInfo.group}/${project}:${checkoutInfo.branch}`
     );
     try {
       await clone(
-        `${context.config.github.serverUrl}/${context.config.github.group}/${project}`,
+        `${context.config.github.serverUrl}/${dependencyInformation.group}/${project}`,
         dir,
         context.config.github.targetBranch
       );
     } catch (err) {
       logger.error(
-        `Error checking out (before merging)  ${context.config.github.serverUrl}/${context.config.github.group}/${project}:${context.config.github.targetBranch}`
+        `Error checking out (before merging)  ${context.config.github.serverUrl}/${dependencyInformation.group}/${project}:${context.config.github.targetBranch}`
       );
       throw err;
     }
@@ -72,10 +73,9 @@ async function checkouProject(context, project, dependencyInformation) {
   }
 }
 
-async function getCheckoutInfo(context, project, mapping) {
+async function getCheckoutInfo(context, targetGroup, project, mapping) {
   const sourceGroup = context.config.github.author;
   const sourceBranch = context.config.github.sourceBranch;
-  const targetGroup = context.config.github.group;
   const targetBranch =
     mapping && mapping.source === context.config.github.targetBranch
       ? mapping.target
@@ -138,6 +138,7 @@ function getDir(project) {
 function readWorkflowInformation(
   triggeringJobName,
   workflowFilePath,
+  defaultGroup,
   dir = "."
 ) {
   const filePath = path.join(dir, workflowFilePath);
@@ -147,11 +148,12 @@ function readWorkflowInformation(
   }
   return parseWorkflowInformation(
     triggeringJobName,
-    getYamlFileContent(filePath)
+    getYamlFileContent(filePath),
+    defaultGroup
   );
 }
 
-function parseWorkflowInformation(jobName, workflowData) {
+function parseWorkflowInformation(jobName, workflowData, defaultGroup) {
   assert(workflowData.jobs[jobName], `The job id '${jobName}' does not exist`);
   const buildChainStep = workflowData.jobs[jobName].steps.find(
     step => step.uses && step.uses.includes("github-action-build-chain")
@@ -167,10 +169,12 @@ function parseWorkflowInformation(jobName, workflowData) {
       buildChainStep.with["build-command-downstream"]
     ),
     childDependencies: dependenciesToObject(
-      buildChainStep.with["child-dependencies"]
+      buildChainStep.with["child-dependencies"],
+      defaultGroup
     ),
     parentDependencies: dependenciesToObject(
-      buildChainStep.with["parent-dependencies"]
+      buildChainStep.with["parent-dependencies"],
+      defaultGroup
     )
   };
 }

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -10,7 +10,8 @@ const { treatCommand } = require("./command/command-treatment-delegator");
 async function start(context) {
   const workflowInformation = readWorkflowInformation(
     context.config.github.jobName,
-    context.config.github.workflow
+    context.config.github.workflow,
+    context.config.github.group
   );
   await treatParents(
     context,
@@ -42,6 +43,7 @@ async function treatParents(
         const parentWorkflowInformation = readWorkflowInformation(
           context.config.github.jobName,
           context.config.github.workflow,
+          context.config.github.group,
           dir
         );
         if (parentWorkflowInformation) {

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -53,21 +53,28 @@ function inspect(obj) {
   return util.inspect(obj, false, null, true);
 }
 
-function dependenciesToObject(dependencies) {
+function dependenciesToObject(dependencies, defaultGroup) {
   const dependenciesObject = {};
   dependencies
     ? dependencies.split(",").forEach(item => {
-        const key = item.trim().includes("@")
-          ? item.trim().split("@")[0]
-          : item.trim();
-        dependenciesObject[key] = item.trim().includes("@")
-          ? {
+        const dependency = item.trim().includes("@")
+          ? item.trim().split("@")
+          : [item, undefined];
+        const groupProject = dependency[0].includes("/")
+          ? dependency[0].trim().split("/")
+          : [defaultGroup, dependency[0]];
+
+        dependency[1]
+          ? (dependenciesObject[groupProject[1].trim()] = {
+              group: groupProject[0],
               mapping: {
-                source: item.split("@")[1].split(":")[0],
-                target: item.split("@")[1].split(":")[1]
+                source: dependency[1].split(":")[0],
+                target: dependency[1].split(":")[1]
               }
-            }
-          : {};
+            })
+          : (dependenciesObject[groupProject[1].trim()] = {
+              group: groupProject[0]
+            });
       })
     : {};
   return dependenciesObject;

--- a/test/build-chain-flow-helper.test.js
+++ b/test/build-chain-flow-helper.test.js
@@ -1,7 +1,8 @@
 const {
   readWorkflowInformation,
   getCheckoutInfo,
-  checkoutDependencies
+  checkoutDependencies,
+  checkouProject
 } = require("../src/lib/build-chain-flow-helper");
 jest.mock("../src/lib/git");
 const {
@@ -11,11 +12,16 @@ const {
   hasPullRequest: hasPullRequestMock
 } = require("../src/lib/git");
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 test("parseWorkflowInformation", () => {
   // Act
   const buildChainInformation = readWorkflowInformation(
     "build-chain",
     "flow.yaml",
+    "defaultGroup",
     "test/resources"
   );
   // Assert
@@ -35,10 +41,16 @@ test("parseWorkflowInformation", () => {
       "mvn -e -nsu -fae -T1C clean install -Dfull -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -DjvmArgs=-Xmx4g"
     ],
     childDependencies: {
-      appformer: { mapping: { source: "7.x", target: "master" } },
-      "lienzo-tests": {}
+      appformer: {
+        group: "defaultGroup",
+        mapping: { source: "7.x", target: "master" }
+      },
+      "lienzo-tests": { group: "defaultGroup" }
     },
-    parentDependencies: { "lienzo-core": {} }
+    parentDependencies: {
+      "lienzo-core": { group: "defaultGroup" },
+      errai: { group: "groupx" }
+    }
   };
   expect(expected).toEqual(buildChainInformation);
 });
@@ -52,13 +64,12 @@ test("getCheckoutInfo. sourceBranch and sourceTarget exist with merge", async ()
       github: {
         author: "author",
         sourceBranch: "sourceBranch",
-        group: "group",
         targetBranch: "targetBranch"
       }
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "projectX");
+  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
   // Assert
   expect(result.group).toEqual("author");
   expect(result.branch).toEqual("sourceBranch");
@@ -80,9 +91,9 @@ test("getCheckoutInfo. group and sourceTarget exist with merge", async () => {
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "projectX");
+  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
   // Assert
-  expect(result.group).toEqual("group");
+  expect(result.group).toEqual("targetGroup");
   expect(result.branch).toEqual("sourceBranch");
   expect(result.merge).toEqual(true);
 });
@@ -96,13 +107,12 @@ test("getCheckoutInfo. sourceBranch and sourceTarget exist without merge", async
       github: {
         author: "author",
         sourceBranch: "sourceBranch",
-        group: "group",
         targetBranch: "targetBranch"
       }
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "projectX");
+  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
   // Assert
   expect(result.group).toEqual("author");
   expect(result.branch).toEqual("sourceBranch");
@@ -118,15 +128,14 @@ test("getCheckoutInfo. group and sourceTarget exist without merge", async () => 
       github: {
         author: "author",
         sourceBranch: "sourceBranch",
-        group: "group",
         targetBranch: "targetBranch"
       }
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "projectX");
+  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
   // Assert
-  expect(result.group).toEqual("group");
+  expect(result.group).toEqual("targetGroup");
   expect(result.branch).toEqual("sourceBranch");
   expect(result.merge).toEqual(false);
 });
@@ -142,15 +151,14 @@ test("getCheckoutInfo. group and targetBranch exist", async () => {
       github: {
         author: "author",
         sourceBranch: "sourceBranch",
-        group: "group",
         targetBranch: "targetBranch"
       }
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "projectX");
+  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
   // Assert
-  expect(result.group).toEqual("group");
+  expect(result.group).toEqual("targetGroup");
   expect(result.branch).toEqual("targetBranch");
   expect(result.merge).toEqual(false);
 });
@@ -166,13 +174,12 @@ test("getCheckoutInfo. none exist", async () => {
       github: {
         author: "author",
         sourceBranch: "sourceBranch",
-        group: "group",
         targetBranch: "targetBranch"
       }
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "projectX");
+  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
   // Assert
   expect(result).toEqual(undefined);
 });
@@ -186,17 +193,25 @@ test("checkoutDependencies", async () => {
         serverUrl: "URL",
         author: "author",
         sourceBranch: "sBranch",
-        group: "group",
         targetBranch: "tBranch"
       }
     }
   };
   const dependencies = {
-    "project-A": {},
-    projectB: { mapping: { source: "tBranch", target: "tBranchMapped" } },
-    projectC: {},
-    projectD: { mapping: { source: "branchX", target: "branchY" } },
-    projectE: { mapping: { source: "branchX", target: "tBranchMapped" } }
+    "project-A": { group: "groupA" },
+    projectB: {
+      group: "groupB",
+      mapping: { source: "tBranch", target: "tBranchMapped" }
+    },
+    projectC: { group: "groupC" },
+    projectD: {
+      group: "groupD",
+      mapping: { source: "branchX", target: "branchY" }
+    },
+    projectE: {
+      group: "groupE",
+      mapping: { source: "branchX", target: "tBranchMapped" }
+    }
   };
   doesBranchExistMock
     .mockResolvedValueOnce(true)
@@ -217,7 +232,7 @@ test("checkoutDependencies", async () => {
   await checkoutDependencies(context, dependencies);
   // Assert
   expect(cloneMock).toHaveBeenCalledWith(
-    "URL/group/project-A",
+    "URL/groupA/project-A",
     "project_A",
     "tBranch"
   );
@@ -228,23 +243,23 @@ test("checkoutDependencies", async () => {
     "sBranch"
   );
   expect(cloneMock).toHaveBeenCalledWith(
-    "URL/group/projectB",
+    "URL/groupB/projectB",
     "projectB",
     "tBranchMapped"
   );
   expect(cloneMock).toHaveBeenCalledWith(
-    "URL/group/projectC",
+    "URL/groupC/projectC",
     "projectC",
     "tBranch"
   );
   expect(mergeMock).toHaveBeenCalledWith(
     "projectC",
-    "group",
+    "groupC",
     "projectC",
     "sBranch"
   );
   expect(cloneMock).toHaveBeenCalledWith(
-    "URL/group/projectD",
+    "URL/groupD/projectD",
     "projectD",
     "tBranch"
   );
@@ -261,8 +276,161 @@ test("checkoutDependencies", async () => {
   );
   expect(mergeMock).not.toHaveBeenCalledWith(
     "projectE",
-    "group",
+    "groupE",
     "projectE",
     "sBranch"
+  );
+});
+
+test("checkouProject author/projectX:sBranch exists has PR", async () => {
+  // Arrange
+  const context = {
+    config: {
+      github: {
+        workflow: "main.yml",
+        serverUrl: "URL",
+        author: "author",
+        sourceBranch: "sBranch",
+        targetBranch: "tBranch"
+      }
+    }
+  };
+  doesBranchExistMock.mockResolvedValueOnce(true);
+  hasPullRequestMock.mockResolvedValueOnce(true);
+  // Act
+  await checkouProject(context, "projectx", { group: "groupx" });
+  // Assert
+  expect(cloneMock).toHaveBeenCalledTimes(1);
+  expect(mergeMock).toHaveBeenCalledTimes(1);
+  expect(cloneMock).toHaveBeenCalledWith(
+    "URL/groupx/projectx",
+    "projectx",
+    "tBranch"
+  );
+  expect(mergeMock).toHaveBeenCalledWith(
+    "projectx",
+    "author",
+    "projectx",
+    "sBranch"
+  );
+});
+
+test("checkouProject author/projectX:sBranch exists has no PR", async () => {
+  // Arrange
+  const context = {
+    config: {
+      github: {
+        workflow: "main.yml",
+        serverUrl: "URL",
+        author: "author",
+        sourceBranch: "sBranch",
+        targetBranch: "tBranch"
+      }
+    }
+  };
+  doesBranchExistMock.mockResolvedValueOnce(true);
+  hasPullRequestMock.mockResolvedValueOnce(false);
+  // Act
+  await checkouProject(context, "projectx", { group: "groupx" });
+  // Assert
+  expect(cloneMock).toHaveBeenCalledTimes(1);
+  expect(cloneMock).toHaveBeenCalledWith(
+    "URL/author/projectx",
+    "projectx",
+    "sBranch"
+  );
+  expect(mergeMock).not.toHaveBeenCalled();
+});
+
+test("checkouProject author/projectX:sBranch does not exists but groupx/projectX:sBranch has PR", async () => {
+  // Arrange
+  const context = {
+    config: {
+      github: {
+        workflow: "main.yml",
+        serverUrl: "URL",
+        author: "author",
+        sourceBranch: "sBranch",
+        targetBranch: "tBranch"
+      }
+    }
+  };
+  doesBranchExistMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+  hasPullRequestMock.mockResolvedValueOnce(true);
+
+  // Act
+  await checkouProject(context, "projectx", { group: "groupx" });
+  // Assert
+  expect(cloneMock).toHaveBeenCalledTimes(1);
+  expect(mergeMock).toHaveBeenCalledTimes(1);
+  expect(cloneMock).toHaveBeenCalledWith(
+    "URL/groupx/projectx",
+    "projectx",
+    "tBranch"
+  );
+  expect(mergeMock).toHaveBeenCalledWith(
+    "projectx",
+    "groupx",
+    "projectx",
+    "sBranch"
+  );
+});
+
+test("checkouProject author/projectX:sBranch does not exists but groupx/projectX:sBranch has no PR", async () => {
+  // Arrange
+  const context = {
+    config: {
+      github: {
+        workflow: "main.yml",
+        serverUrl: "URL",
+        author: "author",
+        sourceBranch: "sBranch",
+        targetBranch: "tBranch"
+      }
+    }
+  };
+  doesBranchExistMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+  hasPullRequestMock.mockResolvedValueOnce(false);
+
+  // Act
+  await checkouProject(context, "projectx", { group: "groupx" });
+  // Assert
+  expect(cloneMock).toHaveBeenCalledTimes(1);
+  expect(mergeMock).toHaveBeenCalledTimes(0);
+  expect(cloneMock).toHaveBeenCalledWith(
+    "URL/groupx/projectx",
+    "projectx",
+    "sBranch"
+  );
+});
+
+test("checkouProject author/projectX:sBranch and groupx/projectX:sBranch but groupx/projectX:tBranch", async () => {
+  // Arrange
+  const context = {
+    config: {
+      github: {
+        workflow: "main.yml",
+        serverUrl: "URL",
+        author: "author",
+        sourceBranch: "sBranch",
+        targetBranch: "tBranch"
+      }
+    }
+  };
+  doesBranchExistMock
+    .mockResolvedValueOnce(false)
+    .mockResolvedValueOnce(false)
+    .mockResolvedValueOnce(true);
+
+  // Act
+  await checkouProject(context, "projectx", { group: "groupx" });
+  // Assert
+  expect(cloneMock).toHaveBeenCalledTimes(1);
+  expect(hasPullRequestMock).toHaveBeenCalledTimes(0);
+  expect(mergeMock).toHaveBeenCalledTimes(0);
+  expect(cloneMock).toHaveBeenCalledWith(
+    "URL/groupx/projectx",
+    "projectx",
+    "tBranch"
   );
 });

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -9,7 +9,13 @@ jest.mock("../src/lib/build-chain-flow-helper");
 test("treatParents", async () => {
   // Arrange
   const context = {
-    config: { github: { jobName: "job-id", workflow: "main.yaml" } }
+    config: {
+      github: {
+        jobName: "job-id",
+        workflow: "main.yaml",
+        group: "defaultGroup"
+      }
+    }
   };
   const workflowInformation = {
     id: "build-chain",
@@ -36,6 +42,7 @@ test("treatParents", async () => {
   expect(readWorkflowInformation).toHaveBeenCalledWith(
     "job-id",
     "main.yaml",
+    "defaultGroup",
     undefined
   );
 });

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -2,11 +2,52 @@ const { dependenciesToObject } = require("../src/lib/common");
 
 test("dependenciesToObject without branch", () => {
   // Arrange
-  const expected = { projectA: {}, projectB: {}, projectC: {}, projectD: {} };
+  const expected = {
+    projectA: { group: "defaultGroup" },
+    projectB: { group: "defaultGroup" },
+    projectC: { group: "defaultGroup" },
+    projectD: { group: "defaultGroup" }
+  };
   // Act
   const dependencies = dependenciesToObject(
-    "projectA,projectB, projectC,projectD"
+    "projectA,projectB, projectC,projectD",
+    "defaultGroup"
   );
+  // Assert
+  expect(dependencies).toEqual(expected);
+});
+
+test("dependenciesToObject without branch and with group", () => {
+  // Arrange
+  const expected = {
+    projectA: { group: "groupx" },
+    projectB: { group: "groupy" },
+    projectC: { group: "groupz" },
+    projectD: { group: "defaultGroup" }
+  };
+  // Act
+  const dependencies = dependenciesToObject(
+    "groupx/projectA,groupy/projectB, groupz/projectC,projectD",
+    "defaultGroup"
+  );
+  // Assert
+  expect(dependencies).toEqual(expected);
+});
+
+test("dependenciesToObject single dependency without group", () => {
+  // Arrange
+  const expected = { projectA: { group: "defaultGroup" } };
+  // Act
+  const dependencies = dependenciesToObject("projectA", "defaultGroup");
+  // Assert
+  expect(dependencies).toEqual(expected);
+});
+
+test("dependenciesToObject single dependency with group", () => {
+  // Arrange
+  const expected = { projectA: { group: "groupx" } };
+  // Act
+  const dependencies = dependenciesToObject("groupx/projectA", "defaultGroup");
   // Assert
   expect(dependencies).toEqual(expected);
 });
@@ -14,14 +55,21 @@ test("dependenciesToObject without branch", () => {
 test("dependenciesToObject with branch", () => {
   // Arrange
   const expected = {
-    projectA: {},
-    projectB: { mapping: { source: "7.x", target: "master" } },
-    projectC: {},
-    projectD: {}
+    projectA: { group: "defaultGroup" },
+    projectB: {
+      group: "defaultGroup",
+      mapping: { source: "7.x", target: "master" }
+    },
+    projectC: { group: "defaultGroup" },
+    projectD: {
+      group: "defaultGroup",
+      mapping: { source: "8.0.0", target: "9.1.1" }
+    }
   };
   // Act
   const dependencies = dependenciesToObject(
-    "projectA,projectB@7.x:master, projectC,projectD"
+    "projectA,projectB@7.x:master, projectC,projectD@8.0.0:9.1.1",
+    "defaultGroup"
   );
   // Assert
   expect(dependencies).toEqual(expected);

--- a/test/fs-helper.test.js
+++ b/test/fs-helper.test.js
@@ -33,7 +33,7 @@ test("readYamlFile", () => {
               "build-command-upstream":
                 "mvn clean | mvn -e -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true",
               "child-dependencies": "appformer@7.x:master,lienzo-tests",
-              "parent-dependencies": "lienzo-core"
+              "parent-dependencies": "lienzo-core,groupx/errai"
             }
           }
         ]

--- a/test/resources/flow.yaml
+++ b/test/resources/flow.yaml
@@ -10,7 +10,7 @@ jobs:
         id: build-chain
         uses: kiegroup/github-action-build-chain@master
         with:
-          parent-dependencies: "lienzo-core"
+          parent-dependencies: "lienzo-core,groupx/errai"
           child-dependencies: "appformer@7.x:master,lienzo-tests"
           build-command: 'mvn clean | mvn -e -nsu -Dfull clean install -Prun-code-coverage -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -DjvmArgs="-Xms1g -Xmx4g -XX:+CMSClassUnloadingEnabled"'
           build-command-upstream: "mvn clean | mvn -e -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true"


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-927
Test performed in https://github.com/Ginxo/lienzo-tests/pull/4/checks?check_run_id=957805290 (don't pay attention to build failures https://github.com/Ginxo/lienzo-tests is not up to date)
```
[WARN]  project github.com/Ginxo/lienzo-core:BXMSPROD-927 does not exist. It's not necessarily an error.
[WARN]  project github.com/kiegroup/lienzo-core:BXMSPROD-927 does not exist. It's not necessarily an error.
[INFO]  Checking out 'https://github.com/kiegroup/lienzo-core:master'  into 'lienzo_core'
```
`kiegroup/lienzo-core` defined in https://github.com/Ginxo/lienzo-tests/blob/0933fceb005176285af1e68b80d5e5c555a92930/.github/workflows/pull_request.yml#L15