### PR TITLE
BXMSPROD-947 merge target project into project triggering the job

### DIFF
--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -14,6 +14,7 @@ async function start(context) {
     logger.info(
       `Merging root project with ${context.config.github.group}/${context.config.github.project}:${context.config.github.targetBranch}`
     );
+    await fetch(".", context.config.github.sourceBranch);
     await fetch(".", context.config.github.targetBranch);
     await merge(
       ".",

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -13,13 +13,18 @@ async function start(context) {
   core.startGroup(
     `Checkout ${context.config.github.group}/${context.config.github.project}.`
   );
+  const rootProjectFolder = getDir(
+    context.config.rootFolder,
+    context.config.github.project
+  );
   await checkouProject(context, context.config.github.project, {
     group: context.config.github.group
   });
   const workflowInformation = readWorkflowInformation(
     context.config.github.jobName,
     context.config.github.workflow,
-    context.config.github.group
+    context.config.github.group,
+    rootProjectFolder
   );
   core.endGroup();
   await treatParents(
@@ -29,7 +34,7 @@ async function start(context) {
     workflowInformation
   );
   await executeBuildCommands(
-    getDir(context.config.rootFolder, context.config.github.project),
+    rootProjectFolder,
     workflowInformation["buildCommands"]
   );
 }

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -48,7 +48,10 @@ async function treatParents(
 ) {
   if (!projectList[project]) {
     projectList.push(project);
-    if (workflowInformation.parentDependencies) {
+    if (
+      workflowInformation.parentDependencies &&
+      Object.keys(workflowInformation.parentDependencies).length > 0
+    ) {
       core.startGroup(
         `Checking out dependencies [${Object.keys(
           workflowInformation.parentDependencies

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -3,7 +3,7 @@ const {
   getDir,
   readWorkflowInformation
 } = require("./build-chain-flow-helper");
-const { merge } = require("./git");
+const { merge, fetch } = require("./git");
 const { logger } = require("./common");
 const { execute } = require("./command");
 const { treatCommand } = require("./command/command-treatment-delegator");
@@ -14,6 +14,7 @@ async function start(context) {
     logger.info(
       `Merging root project with ${context.config.github.group}/${context.config.github.project}:${context.config.github.targetBranch}`
     );
+    await fetch(".", context.config.github.targetBranch);
     await merge(
       ".",
       context.config.github.group,

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -10,6 +10,9 @@ const { treatCommand } = require("./command/command-treatment-delegator");
 
 async function start(context) {
   try {
+    logger.info(
+      `Merging root project with ${context.config.github.group}/${context.config.github.project}:${context.config.github.targetBranch}`
+    );
     await merge(
       ".",
       context.config.github.group,

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -52,7 +52,9 @@ async function treatParents(
     projectList.push(project);
     if (workflowInformation.parentDependencies) {
       core.startGroup(
-        `Checking out dependencies ${workflowInformation.parentDependencies} for project ${project}`
+        `Checking out dependencies [${Object.keys(
+          workflowInformation.parentDependencies
+        ).join(", ")}] for project ${project}`
       );
       await checkoutDependencies(
         context,

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -7,6 +7,7 @@ const { merge } = require("./git");
 const { logger } = require("./common");
 const { execute } = require("./command");
 const { treatCommand } = require("./command/command-treatment-delegator");
+const core = require("@actions/core");
 
 async function start(context) {
   try {
@@ -50,10 +51,14 @@ async function treatParents(
   if (!projectList[project]) {
     projectList.push(project);
     if (workflowInformation.parentDependencies) {
+      core.startGroup(
+        `Checking out dependencies ${workflowInformation.parentDependencies} for project ${project}`
+      );
       await checkoutDependencies(
         context,
         workflowInformation.parentDependencies
       );
+      core.endGroup();
       for (const parentProject of Object.keys(
         workflowInformation.parentDependencies
       ).filter(a => a !== null && a !== "")) {

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -3,11 +3,26 @@ const {
   getDir,
   readWorkflowInformation
 } = require("./build-chain-flow-helper");
+const { merge } = require("./git");
 const { logger } = require("./common");
 const { execute } = require("./command");
 const { treatCommand } = require("./command/command-treatment-delegator");
 
 async function start(context) {
+  try {
+    await merge(
+      ".",
+      context.config.github.group,
+      context.config.github.project,
+      context.config.github.targetBranch
+    );
+  } catch (err) {
+    logger.error(
+      `Error merging ${context.config.github.serverUrl}/${context.config.github.group}/${context.config.github.project}:${context.config.github.targetBranch}. Please manually merge it and relaunch.`
+    );
+    throw err;
+  }
+
   const workflowInformation = readWorkflowInformation(
     context.config.github.jobName,
     context.config.github.workflow,

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -35,7 +35,8 @@ async function start(context) {
   );
   await executeBuildCommands(
     rootProjectFolder,
-    workflowInformation["buildCommands"]
+    workflowInformation["buildCommands"],
+    context.config.github.project
   );
 }
 
@@ -91,15 +92,16 @@ async function treatParents(
       await executeBuildCommands(
         getDir(context.config.rootFolder, project),
         workflowInformation["buildCommandsUpstream"] ||
-          workflowInformation["buildCommands"]
+          workflowInformation["buildCommands"],
+        project
       );
     }
   }
 }
 
-async function executeBuildCommands(cwd, buildCommands) {
+async function executeBuildCommands(cwd, buildCommands, project) {
   for (const command of buildCommands) {
-    await execute(cwd, treatCommand(command));
+    await execute(cwd, treatCommand(command), project);
   }
 }
 

--- a/src/lib/command.js
+++ b/src/lib/command.js
@@ -1,5 +1,6 @@
 const { logger } = require("./common");
 const exec = require("@actions/exec");
+const core = require("@actions/core");
 
 class ExitError extends Error {
   constructor(message, code) {
@@ -9,10 +10,12 @@ class ExitError extends Error {
 }
 
 async function execute(cwd, command) {
+  core.startGroup(`Executing ${command} in dir ${cwd}`);
   logger.info(`Execute command '${command}' in dir '${cwd}'`);
   const options = {};
   options.cwd = cwd;
   await exec.exec(command, [], options);
+  core.endGroup();
 }
 
 module.exports = {

--- a/src/lib/command.js
+++ b/src/lib/command.js
@@ -9,8 +9,8 @@ class ExitError extends Error {
   }
 }
 
-async function execute(cwd, command) {
-  core.startGroup(`Executing ${command} in dir ${cwd}`);
+async function execute(cwd, command, project) {
+  core.startGroup(`[${project}]. Command: '${command}' in dir ${cwd}`);
   logger.info(`Execute command '${command}' in dir '${cwd}'`);
   const options = {};
   options.cwd = cwd;

--- a/src/lib/command/maven-treatment.js
+++ b/src/lib/command/maven-treatment.js
@@ -1,9 +1,5 @@
-const { logger } = require("../common");
-
 function treat(command) {
-  const resultCommand = `${command} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B`;
-  logger.info(`Command ${command} treated to  ${resultCommand}`);
-  return resultCommand;
+  return `${command} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B`;
 }
 
 module.exports = {

--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -81,8 +81,6 @@ async function fetch(dir, branch) {
     dir,
     "fetch",
     "--quiet",
-    "--depth",
-    FETCH_DEPTH,
     "origin",
     `${branch}:refs/remotes/origin/${branch}`
   );

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -7,8 +7,9 @@ const {
 jest.mock("../src/lib/build-chain-flow-helper");
 const { execute } = require("../src/lib/command");
 jest.mock("../src/lib/command");
-const { merge } = require("../src/lib/git");
+const { merge, fetch } = require("../src/lib/git");
 jest.mock("../src/lib/git");
+jest.mock("@actions/core");
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -45,6 +46,8 @@ test("start", async () => {
   // Act
   await start(context);
   // Assert
+  expect(fetch).toHaveBeenCalledWith(".", "tBranch");
+  expect(fetch).toHaveBeenCalledTimes(1);
   expect(merge).toHaveBeenCalledWith(
     ".",
     "defaultGroup",

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -1,5 +1,6 @@
 const { start, treatParents } = require("../src/lib/build-chain-flow");
 const {
+  checkouProject,
   checkoutDependencies,
   getDir,
   readWorkflowInformation
@@ -7,8 +8,6 @@ const {
 jest.mock("../src/lib/build-chain-flow-helper");
 const { execute } = require("../src/lib/command");
 jest.mock("../src/lib/command");
-const { merge, fetch } = require("../src/lib/git");
-jest.mock("../src/lib/git");
 jest.mock("@actions/core");
 
 afterEach(() => {
@@ -42,29 +41,23 @@ test("start", async () => {
     buildCommandsUpstream: ["upstream 1", "upstream 2"],
     buildCommandsDownstream: ["downstream 1", "downstream 2"]
   };
-  readWorkflowInformation.mockReturnValue(workflowInformation);
+  readWorkflowInformation.mockReturnValueOnce(workflowInformation);
+  getDir.mockReturnValueOnce("folder/projectX");
 
   // Act
   await start(context);
   // Assert
-  expect(fetch).toHaveBeenCalledWith(".", "tBranch");
-  expect(fetch).toHaveBeenCalledWith(".", "sBranch");
-  expect(fetch).toHaveBeenCalledTimes(2);
-  expect(merge).toHaveBeenCalledWith(
-    ".",
-    "defaultGroup",
-    "projectX",
-    "tBranch"
-  );
-  expect(merge).toHaveBeenCalledTimes(1);
+  expect(checkouProject).toHaveBeenCalledWith(context, "projectX", {
+    group: "defaultGroup"
+  });
   expect(readWorkflowInformation).toHaveBeenCalledWith(
     "job-id",
     "main.yaml",
     "defaultGroup"
   );
   expect(readWorkflowInformation).toHaveBeenCalledTimes(1);
-  expect(execute).toHaveBeenCalledWith(".", "command 1");
-  expect(execute).toHaveBeenCalledWith(".", "command 2");
+  expect(execute).toHaveBeenCalledWith("folder/projectX", "command 1");
+  expect(execute).toHaveBeenCalledWith("folder/projectX", "command 2");
   expect(execute).toHaveBeenCalledTimes(2);
 });
 

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -24,6 +24,7 @@ test("start", async () => {
         workflow: "main.yaml",
         group: "defaultGroup",
         project: "projectX",
+        sourceBranch: "sBranch",
         targetBranch: "tBranch"
       },
       rootFolder: "folder"
@@ -47,7 +48,8 @@ test("start", async () => {
   await start(context);
   // Assert
   expect(fetch).toHaveBeenCalledWith(".", "tBranch");
-  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(fetch).toHaveBeenCalledWith(".", "sBranch");
+  expect(fetch).toHaveBeenCalledTimes(2);
   expect(merge).toHaveBeenCalledWith(
     ".",
     "defaultGroup",

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -53,7 +53,8 @@ test("start", async () => {
   expect(readWorkflowInformation).toHaveBeenCalledWith(
     "job-id",
     "main.yaml",
-    "defaultGroup"
+    "defaultGroup",
+    "folder/projectX"
   );
   expect(readWorkflowInformation).toHaveBeenCalledTimes(1);
   expect(execute).toHaveBeenCalledWith("folder/projectX", "command 1");

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -57,8 +57,16 @@ test("start", async () => {
     "folder/projectX"
   );
   expect(readWorkflowInformation).toHaveBeenCalledTimes(1);
-  expect(execute).toHaveBeenCalledWith("folder/projectX", "command 1");
-  expect(execute).toHaveBeenCalledWith("folder/projectX", "command 2");
+  expect(execute).toHaveBeenCalledWith(
+    "folder/projectX",
+    "command 1",
+    "projectX"
+  );
+  expect(execute).toHaveBeenCalledWith(
+    "folder/projectX",
+    "command 2",
+    "projectX"
+  );
   expect(execute).toHaveBeenCalledTimes(2);
 });
 

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -1,10 +1,67 @@
-const { treatParents } = require("../src/lib/build-chain-flow");
+const { start, treatParents } = require("../src/lib/build-chain-flow");
 const {
   checkoutDependencies,
   getDir,
   readWorkflowInformation
 } = require("../src/lib/build-chain-flow-helper");
 jest.mock("../src/lib/build-chain-flow-helper");
+const { execute } = require("../src/lib/command");
+jest.mock("../src/lib/command");
+const { merge } = require("../src/lib/git");
+jest.mock("../src/lib/git");
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("start", async () => {
+  // Arrange
+  const context = {
+    config: {
+      github: {
+        jobName: "job-id",
+        workflow: "main.yaml",
+        group: "defaultGroup",
+        project: "projectX",
+        targetBranch: "tBranch"
+      },
+      rootFolder: "folder"
+    }
+  };
+  const workflowInformation = {
+    id: "build-chain",
+    name: "Build Chain",
+    config: {
+      github: {
+        workflow: "main.yaml"
+      }
+    },
+    buildCommands: ["command 1", "command 2"],
+    buildCommandsUpstream: ["upstream 1", "upstream 2"],
+    buildCommandsDownstream: ["downstream 1", "downstream 2"]
+  };
+  readWorkflowInformation.mockReturnValue(workflowInformation);
+
+  // Act
+  await start(context);
+  // Assert
+  expect(merge).toHaveBeenCalledWith(
+    ".",
+    "defaultGroup",
+    "projectX",
+    "tBranch"
+  );
+  expect(merge).toHaveBeenCalledTimes(1);
+  expect(readWorkflowInformation).toHaveBeenCalledWith(
+    "job-id",
+    "main.yaml",
+    "defaultGroup"
+  );
+  expect(readWorkflowInformation).toHaveBeenCalledTimes(1);
+  expect(execute).toHaveBeenCalledWith(".", "command 1");
+  expect(execute).toHaveBeenCalledWith(".", "command 2");
+  expect(execute).toHaveBeenCalledTimes(2);
+});
 
 test("treatParents", async () => {
   // Arrange


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-947
With this change 

- `uses: actions/checkout@v2` is not needed anymore 
- it makes easier the local testing since is the tool itself the one in charge of checking out the project
- the project triggering the job is merged with the target project
- the commands and check outs are grouped in github groups
![image](https://user-images.githubusercontent.com/25130444/90146503-6730ea00-dd81-11ea-8a0d-e89bea191f94.png)
