### PR TITLE
mapping_error fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,6 @@ This is a github action limitation already reported as a suggestion to provide f
 It's not possible to use expressions like `image: "docker://kie-group:github-action-build-chain:{{ inputs.build-chain-build-system }}"`. This way it would be easy to dynamically select image to run with a simple `with` input from flow yml file and we could skip errors like [matrix in uses](#matrix-in-uses).
 Just because of this we have to maintain different Dockerfile definitions in different branches and to tag every branch for every version we release like `python3-cekit-v1`.
 
-
 ### Contributors
 
 <table>

--- a/src/lib/build-chain-flow.js
+++ b/src/lib/build-chain-flow.js
@@ -17,9 +17,14 @@ async function start(context) {
     context.config.rootFolder,
     context.config.github.project
   );
-  await checkoutProject(context, context.config.github.project, {
-    group: context.config.github.group
-  });
+  await checkoutProject(
+    context,
+    context.config.github.project,
+    {
+      group: context.config.github.group
+    },
+    context.config.github.targetBranch
+  );
   const workflowInformation = readWorkflowInformation(
     context.config.github.project,
     context.config.github.jobName,
@@ -35,6 +40,7 @@ async function start(context) {
       context,
       [context.config.github.project],
       context.config.github.project,
+      context.config.github.targetBranch,
       workflowInformation.parentDependencies
     )
   ).reverse();

--- a/src/lib/workflow-informaton-reader.js
+++ b/src/lib/workflow-informaton-reader.js
@@ -10,6 +10,7 @@ async function checkoutParentsAndGetWorkflowInformation(
   context,
   projectList,
   project,
+  currentTargetBranch,
   parentDependencies
 ) {
   if (!projectList[project]) {
@@ -20,7 +21,11 @@ async function checkoutParentsAndGetWorkflowInformation(
           ", "
         )}] for project ${project}`
       );
-      await checkoutDependencies(context, parentDependencies);
+      const checkoutInfos = await checkoutDependencies(
+        context,
+        parentDependencies,
+        currentTargetBranch
+      );
       core.endGroup();
       for (const parentProject of Object.keys(parentDependencies).filter(
         parentDependency => parentDependency !== null && parentDependency !== ""
@@ -41,6 +46,7 @@ async function checkoutParentsAndGetWorkflowInformation(
               context,
               projectList,
               parentProject,
+              checkoutInfos[parentProject].targetBranch,
               parentWorkflowInformation.parentDependencies
             )
           );

--- a/test/build-chain-flow-helper.test.js
+++ b/test/build-chain-flow-helper.test.js
@@ -33,11 +33,17 @@ test("getCheckoutInfo. sourceBranch and sourceTarget exist with merge", async ()
   getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
 
   // Act
-  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
+  const result = await getCheckoutInfo(
+    context,
+    "targetGroup",
+    "projectX",
+    context.config.github.targetBranch
+  );
   // Assert
   expect(result.group).toEqual("sourceGroup");
   expect(result.branch).toEqual("sourceBranch");
   expect(result.merge).toEqual(true);
+  expect(result.targetBranch).toEqual("targetBranch");
 });
 
 test("getCheckoutInfo. group and sourceTarget exist with merge", async () => {
@@ -57,12 +63,18 @@ test("getCheckoutInfo. group and sourceTarget exist with merge", async () => {
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
+  const result = await getCheckoutInfo(
+    context,
+    "targetGroup",
+    "projectX",
+    context.config.github.targetBranch
+  );
   // Assert
   expect(result.project).toEqual("projectX");
   expect(result.group).toEqual("targetGroup");
   expect(result.branch).toEqual("sourceBranch");
   expect(result.merge).toEqual(true);
+  expect(result.targetBranch).toEqual("targetBranch");
 });
 
 test("getCheckoutInfo. sourceBranch and sourceTarget exist without merge", async () => {
@@ -81,12 +93,18 @@ test("getCheckoutInfo. sourceBranch and sourceTarget exist without merge", async
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
+  const result = await getCheckoutInfo(
+    context,
+    "targetGroup",
+    "projectX",
+    context.config.github.targetBranch
+  );
   // Assert
   expect(result.project).toEqual("projectXFroked");
   expect(result.group).toEqual("sourceGroup");
   expect(result.branch).toEqual("sourceBranch");
   expect(result.merge).toEqual(false);
+  expect(result.targetBranch).toEqual("targetBranch");
 });
 
 test("getCheckoutInfo. sourceBranch and sourceTarget exist without merge and not existing forked project", async () => {
@@ -105,12 +123,18 @@ test("getCheckoutInfo. sourceBranch and sourceTarget exist without merge and not
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
+  const result = await getCheckoutInfo(
+    context,
+    "targetGroup",
+    "projectX",
+    context.config.github.targetBranch
+  );
   // Assert
   expect(result.project).toEqual("projectX");
   expect(result.group).toEqual("sourceGroup");
   expect(result.branch).toEqual("sourceBranch");
   expect(result.merge).toEqual(false);
+  expect(result.targetBranch).toEqual("targetBranch");
 });
 
 test("getCheckoutInfo. group and sourceTarget exist without merge", async () => {
@@ -129,12 +153,18 @@ test("getCheckoutInfo. group and sourceTarget exist without merge", async () => 
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
+  const result = await getCheckoutInfo(
+    context,
+    "targetGroup",
+    "projectX",
+    context.config.github.targetBranch
+  );
   // Assert
   expect(result.project).toEqual("projectX");
   expect(result.group).toEqual("targetGroup");
   expect(result.branch).toEqual("sourceBranch");
   expect(result.merge).toEqual(false);
+  expect(result.targetBranch).toEqual("targetBranch");
 });
 
 test("getCheckoutInfo. group and targetBranch exist", async () => {
@@ -155,12 +185,18 @@ test("getCheckoutInfo. group and targetBranch exist", async () => {
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
+  const result = await getCheckoutInfo(
+    context,
+    "targetGroup",
+    "projectX",
+    context.config.github.targetBranch
+  );
   // Assert
   expect(result.project).toEqual("projectX");
   expect(result.group).toEqual("targetGroup");
   expect(result.branch).toEqual("targetBranch");
   expect(result.merge).toEqual(false);
+  expect(result.targetBranch).toEqual("targetBranch");
 });
 
 test("getCheckoutInfo. none exist", async () => {
@@ -182,7 +218,12 @@ test("getCheckoutInfo. none exist", async () => {
     }
   };
   // Act
-  const result = await getCheckoutInfo(context, "targetGroup", "projectX");
+  const result = await getCheckoutInfo(
+    context,
+    "targetGroup",
+    "projectX",
+    context.config.github.targetBranch
+  );
   // Assert
   expect(result).toEqual(undefined);
 });
@@ -202,7 +243,12 @@ test("getCheckoutInfo. group and targetBranch exist. Same owner and group", asyn
     }
   };
   // Act
-  await getCheckoutInfo(context, "sourceGroup", "projectX");
+  await getCheckoutInfo(
+    context,
+    "sourceGroup",
+    "projectX",
+    context.config.github.targetBranch
+  );
   // Assert
   expect(getForkedProjectMock).toHaveBeenCalledTimes(0);
   expect(doesBranchExistMock).toHaveBeenCalledTimes(1);
@@ -212,6 +258,68 @@ test("getCheckoutInfo. group and targetBranch exist. Same owner and group", asyn
     "projectX",
     "sourceBranch"
   );
+});
+
+test("getCheckoutInfo. sourceBranch and sourceTarget exist with merge. Mapping matching", async () => {
+  // Arrange
+  doesBranchExistMock.mockResolvedValueOnce(true);
+  hasPullRequestMock.mockResolvedValueOnce(true);
+  const context = {
+    config: {
+      github: {
+        sourceGroup: "sourceGroup",
+        author: "author",
+        sourceBranch: "sourceBranch",
+        targetBranch: "targetBranch"
+      }
+    }
+  };
+  getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
+
+  // Act
+  const result = await getCheckoutInfo(
+    context,
+    "targetGroup",
+    "projectX",
+    context.config.github.targetBranch,
+    { source: "targetBranch", target: "mappedTargetBranch" }
+  );
+  // Assert
+  expect(result.group).toEqual("sourceGroup");
+  expect(result.branch).toEqual("sourceBranch");
+  expect(result.merge).toEqual(true);
+  expect(result.targetBranch).toEqual("mappedTargetBranch");
+});
+
+test("getCheckoutInfo. sourceBranch and sourceTarget exist with merge. Mapping not matching", async () => {
+  // Arrange
+  doesBranchExistMock.mockResolvedValueOnce(true);
+  hasPullRequestMock.mockResolvedValueOnce(true);
+  const context = {
+    config: {
+      github: {
+        sourceGroup: "sourceGroup",
+        author: "author",
+        sourceBranch: "sourceBranch",
+        targetBranch: "targetBranch"
+      }
+    }
+  };
+  getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
+
+  // Act
+  const result = await getCheckoutInfo(
+    context,
+    "targetGroup",
+    "projectX",
+    context.config.github.targetBranch,
+    { source: "targetBranchX", target: "mappedTargetBranch" }
+  );
+  // Assert
+  expect(result.group).toEqual("sourceGroup");
+  expect(result.branch).toEqual("sourceBranch");
+  expect(result.merge).toEqual(true);
+  expect(result.targetBranch).toEqual("targetBranch");
 });
 
 test("checkoutDependencies", async () => {
@@ -267,7 +375,11 @@ test("checkoutDependencies", async () => {
     .mockResolvedValueOnce({ name: "projectD" })
     .mockResolvedValueOnce({ name: "projectEFroked" });
   // Act
-  await checkoutDependencies(context, dependencies);
+  await checkoutDependencies(
+    context,
+    dependencies,
+    context.config.github.targetBranch
+  );
   // Assert
   expect(cloneMock).toHaveBeenCalledWith(
     "URL/groupA/project-A",
@@ -339,7 +451,12 @@ test("checkoutProject sGroup/projectXFroked:sBranch exists has PR", async () => 
   hasPullRequestMock.mockResolvedValueOnce(true);
   getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
   // Act
-  await checkoutProject(context, "projectx", { group: "groupx" });
+  await checkoutProject(
+    context,
+    "projectx",
+    { group: "groupx" },
+    context.config.github.targetBranch
+  );
   // Assert
   expect(cloneMock).toHaveBeenCalledTimes(1);
   expect(mergeMock).toHaveBeenCalledTimes(1);
@@ -375,7 +492,12 @@ test("checkoutProject sGroup/projectXFroked:sBranch exists has no PR", async () 
   hasPullRequestMock.mockResolvedValueOnce(false);
   getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
   // Act
-  await checkoutProject(context, "projectx", { group: "groupx" });
+  await checkoutProject(
+    context,
+    "projectx",
+    { group: "groupx" },
+    context.config.github.targetBranch
+  );
   // Assert
   expect(cloneMock).toHaveBeenCalledTimes(1);
   expect(cloneMock).toHaveBeenCalledWith(
@@ -406,7 +528,12 @@ test("checkoutProject sGroup/projectX:sBranch does not exists but groupx/project
   getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
 
   // Act
-  await checkoutProject(context, "projectx", { group: "groupx" });
+  await checkoutProject(
+    context,
+    "projectx",
+    { group: "groupx" },
+    context.config.github.targetBranch
+  );
   // Assert
   expect(cloneMock).toHaveBeenCalledTimes(1);
   expect(mergeMock).toHaveBeenCalledTimes(1);
@@ -443,7 +570,12 @@ test("checkoutProject author/projectX:sBranch does not exists but groupx/project
   getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
 
   // Act
-  await checkoutProject(context, "projectx", { group: "groupx" });
+  await checkoutProject(
+    context,
+    "projectx",
+    { group: "groupx" },
+    context.config.github.targetBranch
+  );
   // Assert
   expect(cloneMock).toHaveBeenCalledTimes(1);
   expect(mergeMock).toHaveBeenCalledTimes(1);
@@ -480,7 +612,12 @@ test("checkoutProject author/projectX:sBranch does not exists but groupx/project
   getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
 
   // Act
-  await checkoutProject(context, "projectx", { group: "groupx" });
+  await checkoutProject(
+    context,
+    "projectx",
+    { group: "groupx" },
+    context.config.github.targetBranch
+  );
   // Assert
   expect(cloneMock).toHaveBeenCalledTimes(1);
   expect(mergeMock).toHaveBeenCalledTimes(0);
@@ -513,7 +650,12 @@ test("checkoutProject author/projectX:sBranch and groupx/projectX:sBranch but gr
   getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
 
   // Act
-  await checkoutProject(context, "projectx", { group: "groupx" });
+  await checkoutProject(
+    context,
+    "projectx",
+    { group: "groupx" },
+    context.config.github.targetBranch
+  );
   // Assert
   expect(cloneMock).toHaveBeenCalledTimes(1);
   expect(hasPullRequestMock).toHaveBeenCalledTimes(0);
@@ -522,5 +664,93 @@ test("checkoutProject author/projectX:sBranch and groupx/projectX:sBranch but gr
     "URL/groupx/projectx",
     "folder/projectx",
     "tBranch"
+  );
+});
+
+test("checkoutProject sGroup/projectXFroked:sBranch exists has PR. With mapping matching", async () => {
+  // Arrange
+  const context = {
+    config: {
+      github: {
+        workflow: "main.yml",
+        serverUrl: "URL",
+        author: "author",
+        sourceBranch: "sBranch",
+        targetBranch: "tBranch",
+        sourceGroup: "sGroup"
+      },
+      rootFolder: "folder"
+    }
+  };
+  doesBranchExistMock.mockResolvedValueOnce(true);
+  hasPullRequestMock.mockResolvedValueOnce(true);
+  getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
+  // Act
+  await checkoutProject(
+    context,
+    "projectx",
+    {
+      group: "groupx",
+      mapping: { source: "tBranch", target: "tBranchMapped" }
+    },
+    context.config.github.targetBranch
+  );
+  // Assert
+  expect(cloneMock).toHaveBeenCalledTimes(1);
+  expect(mergeMock).toHaveBeenCalledTimes(1);
+  expect(cloneMock).toHaveBeenCalledWith(
+    "URL/groupx/projectx",
+    "folder/projectx",
+    "tBranchMapped"
+  );
+  expect(mergeMock).toHaveBeenCalledWith(
+    "folder/projectx",
+    "sGroup",
+    "projectXFroked",
+    "sBranch"
+  );
+});
+
+test("checkoutProject sGroup/projectXFroked:sBranch exists has PR. With mapping matching", async () => {
+  // Arrange
+  const context = {
+    config: {
+      github: {
+        workflow: "main.yml",
+        serverUrl: "URL",
+        author: "author",
+        sourceBranch: "sBranch",
+        targetBranch: "tBranch",
+        sourceGroup: "sGroup"
+      },
+      rootFolder: "folder"
+    }
+  };
+  doesBranchExistMock.mockResolvedValueOnce(true);
+  hasPullRequestMock.mockResolvedValueOnce(true);
+  getForkedProjectMock.mockResolvedValueOnce({ name: "projectXFroked" });
+  // Act
+  await checkoutProject(
+    context,
+    "projectx",
+    {
+      group: "groupx",
+      mapping: { source: "tBranch", target: "tBranchMapped" }
+    },
+    context.config.github.targetBranch
+  );
+  // Assert
+  expect(cloneMock).toHaveBeenCalledTimes(1);
+  expect(mergeMock).toHaveBeenCalledTimes(1);
+  expect(cloneMock).toHaveBeenCalledWith(
+    "URL/groupx/projectx",
+    "folder/projectx",
+    "tBranchMapped"
+  );
+  expect(mergeMock).toHaveBeenCalledWith(
+    "folder/projectx",
+    "sGroup",
+    "projectXFroked",
+    "sBranch"
   );
 });

--- a/test/build-chain-flow.test.js
+++ b/test/build-chain-flow.test.js
@@ -49,7 +49,8 @@ test("start no parent dependencies", async () => {
     },
     buildCommands: ["command 1", "command 2"],
     buildCommandsUpstream: ["upstream 1", "upstream 2"],
-    buildCommandsDownstream: ["downstream 1", "downstream 2"]
+    buildCommandsDownstream: ["downstream 1", "downstream 2"],
+    parentDependencies: []
   };
   readWorkflowInformation.mockReturnValueOnce(workflowInformation);
   checkoutParentsAndGetWorkflowInformation.mockResolvedValueOnce([]);
@@ -61,9 +62,14 @@ test("start no parent dependencies", async () => {
   await start(context);
   // Assert
   expect(checkoutProject).toHaveBeenCalledTimes(1);
-  expect(checkoutProject).toHaveBeenCalledWith(context, "projectX", {
-    group: "defaultGroup"
-  });
+  expect(checkoutProject).toHaveBeenCalledWith(
+    context,
+    "projectX",
+    {
+      group: "defaultGroup"
+    },
+    context.config.github.targetBranch
+  );
   expect(readWorkflowInformation).toHaveBeenCalledWith(
     "projectX",
     "job-id",
@@ -73,6 +79,15 @@ test("start no parent dependencies", async () => {
     "folder/projectX"
   );
   expect(readWorkflowInformation).toHaveBeenCalledTimes(1);
+
+  expect(checkoutParentsAndGetWorkflowInformation).toHaveBeenCalledWith(
+    context,
+    [context.config.github.project],
+    context.config.github.project,
+    context.config.github.targetBranch,
+    workflowInformation.parentDependencies
+  );
+
   expect(getDir).toHaveBeenCalledTimes(2);
   expect(execute).toHaveBeenCalledWith(
     "folder/projectX",
@@ -144,6 +159,22 @@ test("start no parent dependencies archive artifacts", async () => {
     name: "artifact1",
     path: "whateverpath"
   });
+  expect(checkoutProject).toHaveBeenCalledTimes(1);
+  expect(checkoutProject).toHaveBeenCalledWith(
+    context,
+    "projectX",
+    {
+      group: "defaultGroup"
+    },
+    context.config.github.targetBranch
+  );
+  expect(checkoutParentsAndGetWorkflowInformation).toHaveBeenCalledWith(
+    context,
+    [context.config.github.project],
+    context.config.github.project,
+    context.config.github.targetBranch,
+    workflowInformation.parentDependencies
+  );
 });
 
 test("start with parent dependencies without upstream command", async () => {
@@ -201,9 +232,14 @@ test("start with parent dependencies without upstream command", async () => {
   await start(context);
   // Assert
   expect(checkoutProject).toHaveBeenCalledTimes(1);
-  expect(checkoutProject).toHaveBeenCalledWith(context, "projectXChild", {
-    group: "defaultGroup"
-  });
+  expect(checkoutProject).toHaveBeenCalledWith(
+    context,
+    "projectXChild",
+    {
+      group: "defaultGroup"
+    },
+    context.config.github.targetBranch
+  );
   expect(readWorkflowInformation).toHaveBeenCalledWith(
     "projectXChild",
     "job-id",
@@ -213,6 +249,15 @@ test("start with parent dependencies without upstream command", async () => {
     "folder/projectXChild"
   );
   expect(readWorkflowInformation).toHaveBeenCalledTimes(1);
+
+  expect(checkoutParentsAndGetWorkflowInformation).toHaveBeenCalledWith(
+    context,
+    [context.config.github.project],
+    context.config.github.project,
+    context.config.github.targetBranch,
+    workflowInformation.parentDependencies
+  );
+
   expect(getDir).toHaveBeenCalledTimes(3);
   expect(execute).toHaveBeenCalledWith(
     "folder/projectXParent",
@@ -283,6 +328,23 @@ test("start with parent dependencies with upstream command", async () => {
   // Act
   await start(context);
   // Assert
+  expect(checkoutProject).toHaveBeenCalledTimes(1);
+  expect(checkoutProject).toHaveBeenCalledWith(
+    context,
+    "projectXChild",
+    {
+      group: "defaultGroup"
+    },
+    context.config.github.targetBranch
+  );
+  expect(checkoutParentsAndGetWorkflowInformation).toHaveBeenCalledWith(
+    context,
+    [context.config.github.project],
+    context.config.github.project,
+    context.config.github.targetBranch,
+    workflowInformation.parentDependencies
+  );
+
   expect(execute).toHaveBeenCalledWith(
     "folder/projectXParent",
     "command-parent-upstream",
@@ -366,6 +428,23 @@ test("start with parent dependencies with archive artifacts with path", async ()
   // Act
   await start(context);
   // Assert
+  expect(checkoutProject).toHaveBeenCalledTimes(1);
+  expect(checkoutProject).toHaveBeenCalledWith(
+    context,
+    "projectXChild",
+    {
+      group: "defaultGroup"
+    },
+    context.config.github.targetBranch
+  );
+  expect(checkoutParentsAndGetWorkflowInformation).toHaveBeenCalledWith(
+    context,
+    [context.config.github.project],
+    context.config.github.project,
+    context.config.github.targetBranch,
+    workflowInformation.parentDependencies
+  );
+
   expect(runUploadArtifactsMock).toHaveBeenCalledTimes(2);
   expect(runUploadArtifactsMock).toHaveBeenCalledWith({
     path: "whateverpath",
@@ -447,6 +526,23 @@ test("start with parent dependencies with archive artifacts one of them without 
   // Act
   await start(context);
   // Assert
+  expect(checkoutProject).toHaveBeenCalledTimes(1);
+  expect(checkoutProject).toHaveBeenCalledWith(
+    context,
+    "projectXChild",
+    {
+      group: "defaultGroup"
+    },
+    context.config.github.targetBranch
+  );
+  expect(checkoutParentsAndGetWorkflowInformation).toHaveBeenCalledWith(
+    context,
+    [context.config.github.project],
+    context.config.github.project,
+    context.config.github.targetBranch,
+    workflowInformation.parentDependencies
+  );
+
   expect(runUploadArtifactsMock).toHaveBeenCalledTimes(1);
   expect(runUploadArtifactsMock).toHaveBeenCalledWith({
     path: "whateverpath",

--- a/test/workflow-informaton-reader.test.js
+++ b/test/workflow-informaton-reader.test.js
@@ -5,7 +5,10 @@ const {
 } = require("../src/lib/workflow-informaton-reader");
 jest.mock("../src/lib/git");
 jest.mock("@actions/core");
-const { getDir } = require("../src/lib/build-chain-flow-helper");
+const {
+  getDir,
+  checkoutDependencies
+} = require("../src/lib/build-chain-flow-helper");
 jest.mock("../src/lib/build-chain-flow-helper");
 
 afterEach(() => {
@@ -21,7 +24,8 @@ test("checkoutParentsAndGetWorkflowInformation no parents", async () => {
         jobName: "build-chain",
         workflow: "flow.yaml",
         group: "groupX",
-        project: project
+        project: project,
+        targetBranch: "tBranch"
       }
     }
   };
@@ -32,6 +36,7 @@ test("checkoutParentsAndGetWorkflowInformation no parents", async () => {
     context,
     projectList,
     project,
+    context.config.github.targetBranch,
     undefined
   );
 
@@ -52,17 +57,23 @@ test("checkoutParentsAndGetWorkflowInformation 1 level", async () => {
         jobName: "build-chain",
         workflow: "flow.yaml",
         group: "groupX",
-        project: project
+        project: project,
+        targetBranch: "tBranch"
       }
     }
   };
 
   const projectList = [];
+
+  checkoutDependencies.mockResolvedValueOnce({
+    "parent-parent": { targetBranch: context.config.github.targetBranch }
+  });
   // Act
   const workflowInformationArray = await checkoutParentsAndGetWorkflowInformation(
     context,
     projectList,
     project,
+    context.config.github.targetBranch,
     { "parent-parent": { group: "groupX" } }
   );
 
@@ -86,17 +97,26 @@ test("checkoutParentsAndGetWorkflowInformation 2 levels", async () => {
         jobName: "build-chain",
         workflow: "flow.yaml",
         group: "groupX",
-        project: project
+        project: project,
+        targetBranch: "tBranch"
       }
     }
   };
 
   const projectList = [];
+  checkoutDependencies
+    .mockResolvedValueOnce({
+      parent: { targetBranch: context.config.github.targetBranch }
+    })
+    .mockResolvedValueOnce({
+      "parent-parent": { targetBranch: context.config.github.targetBranch }
+    });
   // Act
   const workflowInformationArray = await checkoutParentsAndGetWorkflowInformation(
     context,
     projectList,
     project,
+    context.config.github.targetBranch,
     { parent: { group: "groupX" } }
   );
 
@@ -126,17 +146,29 @@ test("checkoutParentsAndGetWorkflowInformation 3 levels", async () => {
         jobName: "build-chain",
         workflow: "flow.yaml",
         group: "groupX",
-        project: project
+        project: project,
+        targetBranch: "tBranch"
       }
     }
   };
 
   const projectList = [];
+  checkoutDependencies
+    .mockResolvedValueOnce({
+      child: { targetBranch: context.config.github.targetBranch }
+    })
+    .mockResolvedValueOnce({
+      parent: { targetBranch: context.config.github.targetBranch }
+    })
+    .mockResolvedValueOnce({
+      "parent-parent": { targetBranch: context.config.github.targetBranch }
+    });
   // Act
   const workflowInformationArray = await checkoutParentsAndGetWorkflowInformation(
     context,
     projectList,
     project,
+    context.config.github.targetBranch,
     { child: { group: "groupX" } }
   );
 
@@ -169,17 +201,26 @@ test("checkoutParentsAndGetWorkflowInformation 3 levels repeated project", async
         jobName: "build-chain",
         workflow: "flow.yaml",
         group: "groupX",
-        project: project
+        project: project,
+        targetBranch: "tBranch"
       }
     }
   };
 
   const projectList = ["parent-parent"];
+  checkoutDependencies
+    .mockResolvedValueOnce({
+      child: { targetBranch: context.config.github.targetBranch }
+    })
+    .mockResolvedValueOnce({
+      parent: { targetBranch: context.config.github.targetBranch }
+    });
   // Act
   const workflowInformationArray = await checkoutParentsAndGetWorkflowInformation(
     context,
     projectList,
     project,
+    context.config.github.targetBranch,
     { child: { group: "groupX" } }
   );
 


### PR DESCRIPTION
error with when
**child**
```
parent-dependency: parent:7.x:master
```
**parent**
```
parent-dependency: parent-parent
```

in case a PR against `7.x` `parent` was properly mapped to `master` but `parent-parent` (it took `7.x`)