### PR TITLE
PLANNER-2474 starting-project argument added to single

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@
 - targetExpression mapping
 - branch flow from GA
 - getForkedProjectName improved
-- issue #158 definition file URL improvements GROUP/BRANCH placeholders
 
 ## Bugs:
 
 - windows error on joining folder https://github.com/kiegroup/github-action-build-chain/issues/153
+- issue #158 definition file URL improvements GROUP/BRANCH placeholders
+- add starting-project CLI argument to single flow type option
+- starting-project argument missing documentation
 
 # V2.5
 

--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ To choose between `pr`, `fd` or `single`
 - **-cct**: You can define a custom command treatment expression. See [Custom Command Replacement](#custom-command-replacement)
 - **-spc**: a list of projects to skip checkout. Something like `-spc 'kiegroup/appformer=./' 'kiegroup/drools=/folderX' `
 - **skipParallelCheckout**: Checkout the project sequencially.
+- **-sp**: The project to start the build from. Something like `-sp=kiegroup/appformer`.
+
 
 Examples:
 
@@ -484,6 +486,8 @@ build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-bui
 - **-cct**: You can define a custom command treatment expression. See [Custom Command Replacement](#custom-command-replacement)
 - **-spc**: a list of projects to skip checkout. Something like `-spc 'kiegroup/appformer=./' 'kiegroup/drools=/folderX' `
 - **skipParallelCheckout**: Checkout the project sequencially.
+- **-sp**: The project to start the build from. Something like `-sp=kiegroup/appformer`.
+
 
 Examples:
 
@@ -499,6 +503,8 @@ build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-bui
 - **-cct**: You can define a custom command treatment expression. See [Custom Command Replacement](#custom-command-replacement)
 - **-spc**: a list of projects to skip checkout. Something like `-spc 'kiegroup/appformer=./' 'kiegroup/drools=/folderX' `
 - **skipParallelCheckout**: Checkout the project sequencially.
+- **-sp**: The project to start the build from. Something like `-sp=kiegroup/appformer`.
+
 
 Examples:
 
@@ -518,6 +524,8 @@ build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-bui
 - **-cct**: You can define a custom command treatment expression. See [Custom Command Replacement](#custom-command-replacement)
 - **-spc**: a list of projects to skip checkout. Something like `-spc 'kiegroup/appformer=./' 'kiegroup/drools=/folderX' `
 - **skipParallelCheckout**: Checkout the project sequencially.
+- **-sp**: The project to start the build from. Something like `-sp=kiegroup/appformer`.
+
 
 Examples:
 

--- a/bin/arguments/build-arguments.js
+++ b/bin/arguments/build-arguments.js
@@ -73,6 +73,7 @@ function singleArguments(subParser) {
   const parser = subParser.add_parser("single", {
     help: "singe flow. Just the project from the url event is treated."
   });
+  startingProjectArgument(parser);
   urlArgument(parser);
   customCommandTreatmentArgument(parser);
   skipProjectCheckout(parser);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "GitHub action to define action chains",
   "main": "dist/build-chain-cli.js",
   "author": "Enrique Mingorance Cano <emingora@redhat.com>",


### PR DESCRIPTION
# JIRA
https://issues.redhat.com/browse/PLANNER-2474
# Related PRs:
* https://github.com/kiegroup/optaplanner/pull/1440
* https://github.com/kiegroup/optaplanner-quickstarts
* https://github.com/kiegroup/kogito-pipelines/pull/215
* https://github.com/kiegroup/kie-jenkins-scripts/pull/1041

> **_Note:_** Please, do not check `dist/index.js` changes. It is automatically generated.
