### PR TITLE
BXMSPROD-1265: Conscientious language initiative

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - master
+      - main
       - 2.5
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See [action.yml](action.yml)
   > ```
   > definition-file: './folder/whatever_definition_file.yaml'
   > definition-file: 'http://yourdomain.com/definition-file.yaml'
-  > definition-file: 'https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml'
+  > definition-file: 'https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml'
   > definition-file: 'https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml'
   > definition-file: 'https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml'
   > definition-file: 'https://raw.githubusercontent.com/${GROUP}/${PROJECT_NAME}/${BRANCH}/.ci/pull-request-config.yaml'
@@ -436,7 +436,7 @@ It is possible to execute build-chain flow anywhere you want (just remember your
 - %GITHUB_EVENT_URL%: the url to your event to test, like `https://github.com/kiegroup/kogito-images/pull/220`.
 - %DEFINITION_FILE%: The workflow definition file path, it can be a path in the filesystem or a URL to the file.
 
-So the final command would look like `env GITHUB_TOKEN=3e6ce1ac1772121d83fbe69ab3c4dd92dad1ae40 ./bin/build-chain-cli.js -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml build pr -url https://github.com/kiegroup/lienzo-core/pull/3`.
+So the final command would look like `env GITHUB_TOKEN=3e6ce1ac1772121d83fbe69ab3c4dd92dad1ae40 ./bin/build-chain-cli.js -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml build pr -url https://github.com/kiegroup/lienzo-core/pull/3`.
 
 ### Local execution
 
@@ -444,14 +444,14 @@ It's possible to use this tool locally, just follow this steps
 
 ```
 (sudo) npm install -g @kie/build-chain-action
-(env GITHUB_TOKEN=3e6ce1ac1772121d83fbe69ab3c4dd92dad1ae40) build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml build pr -url https://github.com/kiegroup/lienzo-core/pull/3
+(env GITHUB_TOKEN=3e6ce1ac1772121d83fbe69ab3c4dd92dad1ae40) build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml build pr -url https://github.com/kiegroup/lienzo-core/pull/3
 ```
 
 either `sudo` and `env GITHUB_TOKEN=...` are optional depending on your local setup.
 
 **Arguments**
 
-- **\*-df**: the definition file, either a path to the filesystem o a URL to it. `-df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml`
+- **\*-df**: the definition file, either a path to the filesystem o a URL to it. `-df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml`
 - **actions**: The action to execute. Possible values `build`, `tools`
   - **build**: See [Build Action](#execution-build-action)
   - **tools**: See [Tools Action](#execution-tools-action)
@@ -473,7 +473,7 @@ To choose between `pr`, `fd` or `single`
 Examples:
 
 ```
-build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml build pr -url https://github.com/kiegroup/kie-wb-distributions/pull/1068
+build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml build pr -url https://github.com/kiegroup/kie-wb-distributions/pull/1068
 ```
 
 ##### Execution Build Action - Full Downstream Build
@@ -488,7 +488,7 @@ build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-bui
 Examples:
 
 ```
-build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml build fdb -url https://github.com/kiegroup/kie-wb-distributions/pull/1068
+build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml build fdb -url https://github.com/kiegroup/kie-wb-distributions/pull/1068
 ```
 
 ##### Execution Build Action - Single Build
@@ -503,7 +503,7 @@ build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-bui
 Examples:
 
 ```
-build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml build single -url https://github.com/kiegroup/kie-wb-distributions/pull/1068
+build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml build single -url https://github.com/kiegroup/kie-wb-distributions/pull/1068
 ```
 
 ##### Execution Build Action - Branch flow arguments
@@ -511,7 +511,7 @@ build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-bui
 **Arguments**:
 
 - **\*-p, -project**: The project name to execute flow from. It has to match with one defined in "definition-file". E.g. `-p=kiegroup/drools`
-- **\*-b, -branch**: The branch to get projects. E.g. `-b=master`
+- **\*-b, -branch**: The branch to get projects. E.g. `-b=main`
 - **-g** (group from project argument): The group to take projects. In case you want to build projects from a different group than the one defined in "definition file". E.g. `-g=Ginxo`
 - **-c, -command**: A command to execute for all the projects, no matter what's defined in "definition file". E.g. `-c="mvn clean"`
 - **--skipExecution**: A command to skip execution, no matter what's defined in "definition file" or in `--command` argument. E.g. `--skipExecution`
@@ -522,11 +522,11 @@ build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-bui
 Examples:
 
 ```
-build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml build branch -url https://github.com/kiegroup/kie-wb-distributions/pull/1068
+build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml build branch -url https://github.com/kiegroup/kie-wb-distributions/pull/1068
 
-build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml build branch -p=kiegroup/lienzo-tests -b=master
+build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml build branch -p=kiegroup/lienzo-tests -b=main
 
-build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml build branch -p=kiegroup/optaplanner -b=7.x -folder=myfolder
+build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml build branch -p=kiegroup/optaplanner -b=7.x -folder=myfolder
 ```
 
 #### Execution Tools Action
@@ -538,7 +538,7 @@ Additionally the tool provides several useful tools
 Examples:
 
 ```
-build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml tools project-list
+build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml tools project-list
 ```
 
 #### Custom Command Replacement

--- a/dist/index.js
+++ b/dist/index.js
@@ -29793,7 +29793,7 @@ async function createCommonConfig(eventData, rootFolder, env) {
         env["GITHUB_BASE_REF"] ||
         (env["GITHUB_REF"]
           ? env["GITHUB_REF"].split("refs/heads/").pop()
-          : undefined), // master
+          : undefined), // main
       jobId: env["GITHUB_JOB"], // build-chain
       sourceRepository: eventData.sourceRepository,
       repository: env["GITHUB_REPOSITORY"], // Ginxo/lienzo-tests

--- a/project-dependencies.yaml
+++ b/project-dependencies.yaml
@@ -41,10 +41,10 @@ dependencies:
       dependencies:
         default:
           - source: 7.x
-            target: master
+            target: main
       dependant:
         default:
-          - source: master
+          - source: main
             target: 7.x
       exclude:
         - kiegroup/optaweb-employee-rostering  
@@ -123,10 +123,10 @@ dependencies:
       dependencies:
         default:
           - source: 7.x
-            target: master
+            target: main
       dependant:
         default:
-          - source: master
+          - source: main
             target: 7.x
       exclude:
         - kiegroup/optaweb-vehicle-routing  
@@ -139,10 +139,10 @@ dependencies:
       dependencies:
         default:
           - source: 7.x
-            target: master
+            target: main
       dependant:
         default:
-          - source: master
+          - source: main
             target: 7.x
       exclude:
         - kiegroup/optaweb-employee-rostering  

--- a/src/lib/flow.yaml
+++ b/src/lib/flow.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Chain
         id: build-chain
-        uses: kiegroup/github-action-build-chain@master
+        uses: kiegroup/github-action-build-chain@main
         with:
           parent-dependencies: "lienzo-core"
           child-dependencies: "appformer"

--- a/src/lib/flows/common/config.js
+++ b/src/lib/flows/common/config.js
@@ -31,7 +31,7 @@ async function createCommonConfig(eventData, rootFolder, env) {
         env["GITHUB_BASE_REF"] ||
         (env["GITHUB_REF"]
           ? env["GITHUB_REF"].split("refs/heads/").pop()
-          : undefined), // master
+          : undefined), // main
       jobId: env["GITHUB_JOB"], // build-chain
       sourceRepository: eventData.sourceRepository,
       repository: env["GITHUB_REPOSITORY"], // Ginxo/lienzo-tests


### PR DESCRIPTION
**Thank you for submitting this pull request**

JIRA: [BXMSPROD-1265](https://issues.redhat.com/browse/BXMSPROD-1265)
https://github.com/kiegroup/github-action-build-chain/pull/163
https://github.com/kiegroup/build-chain-configuration-reader/pull/22

@Ginxo @mareknovotny seems this is missing to execute "build-chain-strategy" for PRs, CBBXMSPROD-1265DBs etc.
Without this each PR logs:

[INFO] Currently running in a labeled security context
 > /usr/bin/chcon --type=ssh_home_t /var/lib/jenkins/caches/git-56a31f1ce5768c8081ce542028192470@tmp/jenkins-gitclient-ssh7479935497790778092.key
 > git fetch --tags --progress origin +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse master^{commit} # timeout=10
ERROR: Could not resolve master
hudson.plugins.git.GitException: Command "git rev-parse master^{commit}" returned status code 128:
stdout: master^{commit}

When you're fine with this please merge.
@Ginxo There are a bunch of changes still to do for/test!!!! This is not covered with this PRs

> **_Note:_** Please, do not check `dist/index.js` changes. It is automatically generated.
