### PR TITLE
[issue 176] Correct mapping handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - issue #158 definition file URL improvements GROUP/BRANCH placeholders
 - add starting-project CLI argument to single flow type option
 - starting-project argument missing documentation
-- look up both current and project triggering mappings
+- look up both current and project triggering mappings. issue #176
 
 # V2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - issue #158 definition file URL improvements GROUP/BRANCH placeholders
 - add starting-project CLI argument to single flow type option
 - starting-project argument missing documentation
+- look up both current and project triggering mappings
 
 # V2.5
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8709,9 +8709,12 @@ function getTarget(
           projectTriggeringTheJobMapping.dependencies.default,
           targetBranch
         );
-      return mapping ? mapping.target : targetBranch;
+      if (mapping) {
+        return mapping.target;
+      }
       // If the current project has a mapping and the source matched with the targetBranch then this mapping is taken
-    } else if (
+    }
+    if (
       currentProjectMapping &&
       currentProjectMapping.dependant &&
       (currentProjectMapping.exclude
@@ -8729,13 +8732,12 @@ function getTarget(
           currentProjectMapping.dependant.default,
           targetBranch
         );
-      return mapping ? mapping.target : targetBranch;
-    } else {
-      return targetBranch;
+      if (mapping) {
+        return mapping.target;
+      }
     }
-  } else {
-    return targetBranch;
   }
+  return targetBranch;
 }
 
 function getMappingInfo(currentProject, mapping, sourceBranch) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "2.3.10",
+  "version": "2.3.11",
   "description": "GitHub action to define action chains",
   "main": "dist/build-chain-cli.js",
   "author": "Enrique Mingorance Cano <emingora@redhat.com>",

--- a/src/lib/flows/common/build-chain-flow-helper.js
+++ b/src/lib/flows/common/build-chain-flow-helper.js
@@ -403,9 +403,12 @@ function getTarget(
           projectTriggeringTheJobMapping.dependencies.default,
           targetBranch
         );
-      return mapping ? mapping.target : targetBranch;
+      if (mapping) {
+        return mapping.target;
+      }
       // If the current project has a mapping and the source matched with the targetBranch then this mapping is taken
-    } else if (
+    }
+    if (
       currentProjectMapping &&
       currentProjectMapping.dependant &&
       (currentProjectMapping.exclude
@@ -423,13 +426,12 @@ function getTarget(
           currentProjectMapping.dependant.default,
           targetBranch
         );
-      return mapping ? mapping.target : targetBranch;
-    } else {
-      return targetBranch;
+      if (mapping) {
+        return mapping.target;
+      }
     }
-  } else {
-    return targetBranch;
   }
+  return targetBranch;
 }
 
 function getMappingInfo(currentProject, mapping, sourceBranch) {

--- a/test/lib/flows/common/build-chain-flow-helper.test.js
+++ b/test/lib/flows/common/build-chain-flow-helper.test.js
@@ -1902,6 +1902,124 @@ test("getTarget targetBranch same. No project triggering job mapping. Mapping ta
   expect(result).toStrictEqual("main");
 });
 
+test("getTarget targetBranch same. Both have mapping. Mapping taken from dependencies (from default)", () => {
+  // Arrange
+  const projectTriggeringTheJob = "projectB";
+  const projectTriggeringTheJobMapping = {
+    dependencies: {
+      default: [
+        {
+          source: "7.x",
+          target: "main"
+        }
+      ]
+    },
+    dependant: {
+      default: [
+        {
+          source: "main",
+          target: "7.x"
+        }
+      ]
+    }
+  };
+  const currentProject = "projectD";
+  const currentProjectMapping = {
+    dependencies: {
+      default: [
+        {
+          source: "8.x",
+          target: "branchX"
+        }
+      ]
+    },
+    dependant: {
+      default: [
+        {
+          source: "branchX",
+          target: "8.x"
+        }
+      ]
+    }
+  };
+  const targetBranch = "branchX";
+  // Act
+  const result = getTarget(
+    projectTriggeringTheJob,
+    projectTriggeringTheJobMapping,
+    currentProject,
+    currentProjectMapping,
+    targetBranch
+  );
+  // Assert
+  expect(result).toStrictEqual("8.x");
+});
+
+test("getTarget targetBranch same. Both have mapping. Mapping taken from dependencies (from project mapping)", () => {
+  // Arrange
+  const projectTriggeringTheJob = "projectB";
+  const projectTriggeringTheJobMapping = {
+    dependencies: {
+      default: [
+        {
+          source: "7.x",
+          target: "main"
+        }
+      ],
+      projectB: [
+        {
+          source: "9.x",
+          target: "main"
+        }
+      ]
+    },
+    dependant: {
+      default: [
+        {
+          source: "main",
+          target: "7.x"
+        }
+      ]
+    }
+  };
+  const currentProject = "projectD";
+  const currentProjectMapping = {
+    dependencies: {
+      default: [
+        {
+          source: "8.x",
+          target: "branchX"
+        }
+      ]
+    },
+    dependant: {
+      default: [
+        {
+          source: "branchY",
+          target: "8.x"
+        }
+      ],
+      projectB: [
+        {
+          source: "branchX",
+          target: "9.x"
+        }
+      ]
+    }
+  };
+  const targetBranch = "branchX";
+  // Act
+  const result = getTarget(
+    projectTriggeringTheJob,
+    projectTriggeringTheJobMapping,
+    currentProject,
+    currentProjectMapping,
+    targetBranch
+  );
+  // Assert
+  expect(result).toStrictEqual("9.x");
+});
+
 test("getTarget targetBranch same. projectB mapping main", () => {
   // Arrange
   const projectTriggeringTheJob = "projectB";


### PR DESCRIPTION
**Thank you for submitting this pull request**

fix https://github.com/kiegroup/github-action-build-chain/issues/176

The build-chain will look for a mapping on both `currentProject` and `projectTriggeringTheJob` before returning the default targetBranch.