### PR TITLE
changed execute node chain argument from node to ExecutionNode

### DIFF
--- a/src/domain/node-execution.ts
+++ b/src/domain/node-execution.ts
@@ -1,5 +1,12 @@
+import { Node } from "@bc/domain/node";
+
 export enum NodeExecutionLevel {
   UPSTREAM = "upstream",
   CURRENT = "current",
   DOWNSTREAM = "downstream",
+}
+
+export type NodeExecution = {
+  node: Node,
+  cwd?: string
 }

--- a/src/service/command/execute-command-service.ts
+++ b/src/service/command/execute-command-service.ts
@@ -24,12 +24,12 @@ export class ExecuteCommandService {
 
   public async executeChainCommands(nodes: NodeExecution[], executionPhase: ExecutionPhase): Promise<ExecuteNodeResult[]> {
     const result: ExecuteNodeResult[] = [];
-    for (const node of nodes.values()) {
-      const commands = this.getNodeCommands(node.node, executionPhase, this._configurationService.getNodeExecutionLevel(node.node));
+    for (const {node, cwd} of nodes) {
+      const commands = this.getNodeCommands(node, executionPhase, this._configurationService.getNodeExecutionLevel(node));
       if (commands?.length) {
-        result.push(await this.executeNodeCommands(node.node, commands, this._configurationService.skipExecution(node.node), node.cwd));
+        result.push(await this.executeNodeCommands(node, commands, this._configurationService.skipExecution(node), cwd));
       } else {
-        result.push({ node: node.node });
+        result.push({ node });
       }
     }
     return result;
@@ -40,7 +40,7 @@ export class ExecuteCommandService {
       node,
       executeCommandResults: [],
     };
-    for await (const command of commands.values()) {
+    for await (const command of commands) {
       result.executeCommandResults?.push(skipExecution ?
         {
           startingDate: Date.now(),

--- a/src/service/command/execute-command-service.ts
+++ b/src/service/command/execute-command-service.ts
@@ -5,9 +5,9 @@ import { CommandExecutorDelegator } from "@bc/service/command/executor/command-e
 import { ExecuteNodeResult } from "@bc/domain/execute-node-result";
 import { LoggerServiceFactory } from "@bc/service/logger/logger-service-factory";
 import { Node } from "@bc/domain/node";
-import { NodeExecutionLevel } from "@bc/domain/node-execution-level";
 import { ExecutionPhase } from "@bc/domain/execution-phase";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
+import { NodeExecution, NodeExecutionLevel } from "@bc/domain/node-execution";
 
 @Service()
 export class ExecuteCommandService {
@@ -22,14 +22,14 @@ export class ExecuteCommandService {
     return this._commandExecutorDelegator.executeCommand(treatedCommand, cwd);
   }
 
-  public async executeChainCommands(nodes: Node[], executionPhase: ExecutionPhase, cwd?: string): Promise<ExecuteNodeResult[]> {
+  public async executeChainCommands(nodes: NodeExecution[], executionPhase: ExecutionPhase): Promise<ExecuteNodeResult[]> {
     const result: ExecuteNodeResult[] = [];
     for (const node of nodes.values()) {
-      const commands = this.getNodeCommands(node, executionPhase, this._configurationService.getNodeExecutionLevel(node));
+      const commands = this.getNodeCommands(node.node, executionPhase, this._configurationService.getNodeExecutionLevel(node.node));
       if (commands?.length) {
-        result.push(await this.executeNodeCommands(node, commands, this._configurationService.skipExecution(node), cwd));
+        result.push(await this.executeNodeCommands(node.node, commands, this._configurationService.skipExecution(node.node), node.cwd));
       } else {
-        result.push({ node });
+        result.push({ node: node.node });
       }
     }
     return result;

--- a/src/service/config/configuration-service.ts
+++ b/src/service/config/configuration-service.ts
@@ -1,5 +1,5 @@
 import Container, { Service } from "typedi";
-import { NodeExecutionLevel } from "@bc/domain/node-execution-level";
+import { NodeExecutionLevel } from "@bc/domain/node-execution";
 import { constants } from "@bc/domain/constants";
 import { EntryPoint } from "@bc/domain/entry-point";
 import { CLIConfiguration } from "@bc/service/config/cli-configuration";

--- a/test/unitary/service/command/execute-command-service.test.ts
+++ b/test/unitary/service/command/execute-command-service.test.ts
@@ -197,7 +197,7 @@ describe("executeChainCommands", () => {
     const executeCommandService = new ExecuteCommandService(commandTreatmentDelegator, commandExecutorDelegator, configurationService);
 
     // Act
-    const result = await executeCommandService.executeChainCommands(nodes.map((node) => {return {node, cwd};}), executionPhase);
+    const result = await executeCommandService.executeChainCommands(nodes.map(node => ({node, cwd})), executionPhase);
 
     // Assert
     expect(commandExecutorDelegator.executeCommand).toHaveBeenCalledTimes(expectedNumberOfCalls);

--- a/test/unitary/service/command/execute-command-service.test.ts
+++ b/test/unitary/service/command/execute-command-service.test.ts
@@ -4,7 +4,7 @@ import { CommandExecutorDelegator } from "@bc/service/command/executor/command-e
 import { ExecutionResult } from "@bc/domain/execute-command-result";
 import { ExecutionPhase } from "@bc/domain/execution-phase";
 import { defaultValue as nodeDefaultValue, Node } from "@bc/domain/node";
-import { NodeExecutionLevel } from "@bc/domain/node-execution-level";
+import { NodeExecutionLevel } from "@bc/domain/node-execution";
 import { TestLoggerService } from "@bc/service/logger/__mocks__/test-logger-service";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
 
@@ -197,7 +197,7 @@ describe("executeChainCommands", () => {
     const executeCommandService = new ExecuteCommandService(commandTreatmentDelegator, commandExecutorDelegator, configurationService);
 
     // Act
-    const result = await executeCommandService.executeChainCommands(nodes, executionPhase, cwd);
+    const result = await executeCommandService.executeChainCommands(nodes.map((node) => {return {node, cwd};}), executionPhase);
 
     // Assert
     expect(commandExecutorDelegator.executeCommand).toHaveBeenCalledTimes(expectedNumberOfCalls);

--- a/test/unitary/service/config/configuration-service.test.ts
+++ b/test/unitary/service/config/configuration-service.test.ts
@@ -8,7 +8,7 @@ import Container from "typedi";
 import path from "path";
 import { BaseConfiguration } from "@bc/service/config/base-configuration";
 import fs from "fs";
-import { NodeExecutionLevel } from "@bc/domain/node-execution-level";
+import { NodeExecutionLevel } from "@bc/domain/node-execution";
 import { TreatmentOptions } from "@bc/domain/treatment-options";
 import { Node } from "@bc/domain/node";
 import { getOrderedListForTree, getTree, readDefinitionFile } from "@kie/build-chain-configuration-reader";


### PR DESCRIPTION
In preparation of flow service #255 

Each node in node chain should execute commands in its own directory. So instead of having a single global `cwd` parameter in `executeChainCommands`, we will use a new type which contains 2 fields `cwd` and `node` and use an array of that type to execute the node chain. This way each node can be executed in its own working directory.