### PR TITLE
Executor refactor

### DIFF
--- a/src/domain/execute-command-result.ts
+++ b/src/domain/execute-command-result.ts
@@ -1,10 +1,10 @@
 export interface ExecuteCommandResult {
-  startingDate?: number;
-  endingDate?: number;
-  time?: number;
-  result?: ExecutionResult;
-  errorMessage?: string;
-  command?: string;
+  startingDate: number;
+  endingDate: number;
+  time: number;
+  result: ExecutionResult;
+  errorMessage: string;
+  command: string;
 }
 
 export enum ExecutionResult {

--- a/src/domain/execute-node-result.ts
+++ b/src/domain/execute-node-result.ts
@@ -3,5 +3,5 @@ import { Node } from "@bc/domain/node";
 
 export interface ExecuteNodeResult {
   node: Node;
-  executeCommandResults?: ExecuteCommandResult[];
+  executeCommandResults: ExecuteCommandResult[];
 }

--- a/src/service/command/executor/command-executor-delegator.ts
+++ b/src/service/command/executor/command-executor-delegator.ts
@@ -14,28 +14,24 @@ export class CommandExecutorDelegator {
 
   public async executeCommand(command: string, cwd?: string): Promise<ExecuteCommandResult> {
     const startHrTime = process.hrtime();
-    let result: ExecuteCommandResult = {
-      startingDate: Date.now(),
-      command: command,
-    };
-
+    const startingDate = Date.now();
+    let result: ExecutionResult;
+    let errorMessage = "";
+    
     try {
       this.isExport(command) ? await this._exportExecutor.execute(command, cwd) : await this._bashExecutor.execute(command, cwd);
-      result = {
-        ...result,
-        result: ExecutionResult.OK,
-      };
+      result = ExecutionResult.OK;
     } catch (ex) {
-      const errorMessage = (ex instanceof Error) ? ex.message : "unknown";
+      errorMessage = (ex instanceof Error) ? ex.message : "unknown";
       LoggerServiceFactory.getInstance().error(`Error executing command ${command}. ${errorMessage}`);
-      result = {
-        ...result,
-        result: ExecutionResult.NOT_OK,
-        errorMessage,
-      };
+      result = ExecutionResult.NOT_OK;
     }
     return {
-      ...result,
+      startingDate,
+      command,
+      result,
+      errorMessage,
+      endingDate: Date.now(),
       time: hrtimeToMs(startHrTime),
     };
   }

--- a/test/unitary/service/command/execute-command-service.test.ts
+++ b/test/unitary/service/command/execute-command-service.test.ts
@@ -222,7 +222,7 @@ describe("executeChainCommands", () => {
         time: 3,
         result: ExecutionResult.OK,
         command: "commandx",
-      })) : undefined,
+      })) : [],
     }));
     expect(result.map(r => r.executeCommandResults)).toStrictEqual(expectedResult.map(r => r.executeCommandResults));
   });

--- a/test/unitary/service/command/executor/command-executor-delegator.test.ts
+++ b/test/unitary/service/command/executor/command-executor-delegator.test.ts
@@ -45,6 +45,8 @@ describe("isExport", () => {
       command: "export VARIABLE=VALUE",
       result: ExecutionResult.OK,
       startingDate: expect.any(Number),
+      endingDate: expect.any(Number),
+      errorMessage: "",
       time: 1000,
     });
     expect(bashExecutor.execute).toHaveBeenCalledTimes(0);
@@ -74,6 +76,8 @@ describe("isExport", () => {
       command: "export VARIABLE=VALUE",
       result: ExecutionResult.OK,
       startingDate: expect.any(Number),
+      endingDate: expect.any(Number),
+      errorMessage: "",
       time: 2000,
     });
     expect(bashExecutor.execute).toHaveBeenCalledTimes(0);
@@ -103,6 +107,7 @@ describe("isExport", () => {
       errorMessage: "whatever the error message",
       result: ExecutionResult.NOT_OK,
       startingDate: expect.any(Number),
+      endingDate: expect.any(Number),
       time: 1000
     });
     expect(bashExecutor.execute).toHaveBeenCalledTimes(0);
@@ -136,6 +141,8 @@ describe("not export command", () => {
       result: ExecutionResult.OK,
       startingDate: expect.any(Number),
       time: 1000,
+      endingDate: expect.any(Number),
+      errorMessage: "",
     });
     expect(bashExecutor.execute).toHaveBeenCalledTimes(1);
     expect(exportExecutor.execute).toHaveBeenCalledTimes(0);
@@ -165,6 +172,8 @@ describe("not export command", () => {
       result: ExecutionResult.OK,
       startingDate: expect.any(Number),
       time: 1000,
+      endingDate: expect.any(Number),
+      errorMessage: "",
     });
     expect(bashExecutor.execute).toHaveBeenCalledTimes(1);
     expect(exportExecutor.execute).toHaveBeenCalledTimes(0);
@@ -194,6 +203,7 @@ describe("not export command", () => {
       result: ExecutionResult.NOT_OK,
       startingDate: expect.any(Number),
       time: 1000,
+      endingDate: expect.any(Number),
     });
     expect(bashExecutor.execute).toHaveBeenCalledTimes(1);
     expect(exportExecutor.execute).toHaveBeenCalledTimes(0);

--- a/test/unitary/service/pre-post/post.test.ts
+++ b/test/unitary/service/pre-post/post.test.ts
@@ -6,6 +6,7 @@ import { constants } from "@bc/domain/constants";
 import { EntryPoint } from "@bc/domain/entry-point";
 import * as core from "@actions/core";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
+import { ExecuteCommandResult, ExecutionResult } from "@bc/domain/execute-command-result";
 
 // just for initialization otherwise not relevant to testing
 Container.set(constants.CONTAINER.ENTRY_POINT, EntryPoint.GITHUB_EVENT);
@@ -13,6 +14,15 @@ Container.set(constants.CONTAINER.ENTRY_POINT, EntryPoint.GITHUB_EVENT);
 jest.spyOn(global.console, "log");
 jest.spyOn(core, "startGroup").mockImplementation(() => undefined);
 jest.spyOn(core, "endGroup").mockImplementation(() => undefined);
+
+const emptyCommandResult: ExecuteCommandResult = {
+  startingDate: 0,
+  endingDate: 0,
+  command: "",
+  result: ExecutionResult.OK,
+  time: 0,
+  errorMessage: ""
+};
 
 describe("On success", () => {
   let post: PostExecutor;
@@ -35,9 +45,7 @@ describe("On success", () => {
         success: cmds,
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => {
-      return {};
-    });
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(executedCmds.length);
     executedCmds.forEach((cmd) => {
@@ -55,9 +63,7 @@ describe("On success", () => {
         always: cmds,
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => {
-      return {};
-    });
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(executedCmds.length * 2);
     [...executedCmds, ...executedCmds].forEach((cmd) => {
@@ -71,9 +77,7 @@ describe("On success", () => {
         failure: "cmd",
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => {
-      return {};
-    });
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(0);
   });
@@ -100,9 +104,7 @@ describe("On failure", () => {
         failure: cmds,
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => {
-      return {};
-    });
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(executedCmds.length);
     executedCmds.forEach((cmd) => {
@@ -120,9 +122,7 @@ describe("On failure", () => {
         always: cmds,
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => {
-      return {};
-    });
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
 
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(executedCmds.length * 2);
@@ -137,9 +137,7 @@ describe("On failure", () => {
         success: "cmd",
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => {
-      return {};
-    });
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
 
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(0);
@@ -150,9 +148,7 @@ test("no post", async () => {
   jest.spyOn(ConfigurationService.prototype, "getPost").mockImplementationOnce(() => {
     return {};
   });
-  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => {
-    return {};
-  });
+  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
   const post = Container.get(PostExecutor);
   await post.run();
   expect(execSpy).toHaveBeenCalledTimes(0);

--- a/test/unitary/service/pre-post/pre.test.ts
+++ b/test/unitary/service/pre-post/pre.test.ts
@@ -7,6 +7,7 @@ import Container from "typedi";
 import { ExecuteCommandService } from "@bc/service/command/execute-command-service";
 import * as core from "@actions/core";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
+import { ExecuteCommandResult, ExecutionResult } from "@bc/domain/execute-command-result";
 
 // just for initialization otherwise not relevant to testing
 Container.set(constants.CONTAINER.ENTRY_POINT, EntryPoint.GITHUB_EVENT);
@@ -16,14 +17,21 @@ jest.spyOn(global.console, "log");
 jest.spyOn(core, "startGroup").mockImplementation(() => undefined);
 jest.spyOn(core, "endGroup").mockImplementation(() => undefined);
 
+const emptyCommandResult: ExecuteCommandResult = {
+  startingDate: 0,
+  endingDate: 0,
+  command: "",
+  result: ExecutionResult.OK,
+  time: 0,
+  errorMessage: ""
+};
+
 test.each([
   ["single command", "cmd", ["cmd"]],
   ["multiple commands", ["cmd1", "cmd2"], ["cmd1", "cmd2"]],
 ])("%p", async (_title: string, cmds: Pre, executedCmds: string[]) => {
   jest.spyOn(ConfigurationService.prototype, "getPre").mockImplementation(() => cmds);
-  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementation(async (_cmd: string, _cwd?: string) => {
-    return {};
-  });
+  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementation(async (_cmd: string, _cwd?: string) => emptyCommandResult);
   const pre = Container.get(PreExecutor);
   await pre.run();
   expect(execSpy).toHaveBeenCalledTimes(executedCmds.length);
@@ -34,9 +42,7 @@ test.each([
 
 test("no pre", async () => {
   jest.spyOn(ConfigurationService.prototype, "getPre").mockImplementation(() => undefined);
-  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementation(async (_cmd: string, _cwd?: string) => {
-    return {};
-  });
+  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementation(async (_cmd: string, _cwd?: string) => emptyCommandResult);
   const pre = Container.get(PreExecutor);
   await pre.run();
   expect(execSpy).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
Realized that I needed more changes in the executor service to implement the flow service

Changed `ExecuteCommandResult` to contain no optional fields. Needed for easy printing of execution results in flow service
Changed `ExecuteNodeResult.executeCommandResults` to be a non optional array field. When there are no commands executed it will simply be an empty array instead of being undefined
Changed scope for `getNodeCommands` to public. Need this method while printing the execution plan (i.e. before the actual execution)
Made other changes to `executeNodeCommands`, `executeCommand` and test cases to accommodate for the above changes