### PR TITLE
Artifact node chain

### DIFF
--- a/src/service/artifacts/artifact-service.ts
+++ b/src/service/artifacts/artifact-service.ts
@@ -24,10 +24,10 @@ export class ArtifactService {
         result = [startingNode];
         break;
       case ArchiveDependencies.ALL:
-        result = nodeChain.filter((node) => !!node.archiveArtifacts);
+        result = nodeChain.filter(node => !!node.archiveArtifacts);
         break;
       default:
-        result = nodeChain.filter((node) => node.archiveArtifacts && (dependencies.includes(node.project) || node.project === startingNode.project));
+        result = nodeChain.filter(node => node.archiveArtifacts && (dependencies.includes(node.project) || node.project === startingNode.project));
     }
     return result;
   }

--- a/src/service/artifacts/artifact-service.ts
+++ b/src/service/artifacts/artifact-service.ts
@@ -19,22 +19,22 @@ export class ArtifactService {
     this.logger = LoggerServiceFactory.getInstance();
   }
 
-  private getNodesToArchive(nodeChain: Node[]): Node[] {
+  private getNodesToArchive(): Node[] {
     const startingProject = this.configService.getStarterNode();
     const dependencies = startingProject.archiveArtifacts?.dependencies ?? ArchiveDependencies.NONE;
     let result: Node[];
     if (dependencies === ArchiveDependencies.NONE) {
       result = [startingProject];
     } else if (dependencies === ArchiveDependencies.ALL) {
-      result = nodeChain.filter((node) => !!node.archiveArtifacts);
+      result = this.configService.nodeChain.filter((node) => !!node.archiveArtifacts);
     } else {
-      result = nodeChain.filter((node) => node.archiveArtifacts && (dependencies.includes(node.project) || this.configService.isNodeStarter(node)));
+      result = this.configService.nodeChain.filter((node) => node.archiveArtifacts && (dependencies.includes(node.project) || this.configService.isNodeStarter(node)));
     }
     return result;
   }
 
-  async uploadNodes(nodesChain: Node[]): Promise<PromiseSettledResult<UploadResponse>[]> {
-    const nodesToArchive = this.getNodesToArchive(nodesChain);
+  async uploadNodes(): Promise<PromiseSettledResult<UploadResponse>[]> {
+    const nodesToArchive = this.getNodesToArchive();
     this.logger.info(nodesToArchive.length > 0 ? `Archiving artifacts for ${nodesToArchive.map((node) => node.project)}` : "No artifacts to archive");
     const promises = nodesToArchive.map(async (node) => {
       this.logger.info(`Project [${node.project}]. Uploading artifacts...`);

--- a/test/unitary/service/artifacts/artifact-service.test.ts
+++ b/test/unitary/service/artifacts/artifact-service.test.ts
@@ -55,9 +55,10 @@ test.each([
   });
   jest.spyOn(ConfigurationService.prototype, "getStarterProjectName").mockImplementation(() => nodeChain[startProjectIndex].project);
   jest.spyOn(ConfigurationService.prototype, "getStarterNode").mockImplementation(() => nodeChain[startProjectIndex]);
+  jest.spyOn(ConfigurationService.prototype, "nodeChain", "get").mockImplementation(() => nodeChain);
 
   const artifactService = Container.get(ArtifactService);
-  await artifactService.uploadNodes(nodeChain);
+  await artifactService.uploadNodes();
   expect(spyUpload).toHaveBeenCalledTimes(nodesToArchive.length);
   nodesToArchive.forEach((node) => {
     expect(spyUpload).toHaveBeenCalledWith(node.archiveArtifacts);

--- a/test/unitary/service/artifacts/artifact-service.test.ts
+++ b/test/unitary/service/artifacts/artifact-service.test.ts
@@ -4,7 +4,6 @@ import { EntryPoint } from "@bc/domain/entry-point";
 import { Node } from "@bc/domain/node";
 import { UploadService } from "@bc/service/artifacts/upload-service";
 import Container from "typedi";
-import { ConfigurationService } from "@bc/service/config/configuration-service";
 import { ArtifactService } from "@bc/service/artifacts/artifact-service";
 
 // disable logs
@@ -53,12 +52,8 @@ test.each([
       size: 0,
     };
   });
-  jest.spyOn(ConfigurationService.prototype, "getStarterProjectName").mockImplementation(() => nodeChain[startProjectIndex].project);
-  jest.spyOn(ConfigurationService.prototype, "getStarterNode").mockImplementation(() => nodeChain[startProjectIndex]);
-  jest.spyOn(ConfigurationService.prototype, "nodeChain", "get").mockImplementation(() => nodeChain);
-
   const artifactService = Container.get(ArtifactService);
-  await artifactService.uploadNodes();
+  await artifactService.uploadNodes(nodeChain, nodeChain[startProjectIndex]);
   expect(spyUpload).toHaveBeenCalledTimes(nodesToArchive.length);
   nodesToArchive.forEach((node) => {
     expect(spyUpload).toHaveBeenCalledWith(node.archiveArtifacts);


### PR DESCRIPTION
Updated artifact service to use node chain directly from config service
(same logic applies as discussed when we made the same change for checkout service)