### PR TITLE
Flow service

### DIFF
--- a/src/domain/execute-command-result.ts
+++ b/src/domain/execute-command-result.ts
@@ -8,7 +8,7 @@ export interface ExecuteCommandResult {
 }
 
 export enum ExecutionResult {
-  OK,
-  NOT_OK,
-  SKIP,
+  OK = "OK",
+  NOT_OK = "NOT OK",
+  SKIP = "SKIP",
 }

--- a/src/domain/flow.ts
+++ b/src/domain/flow.ts
@@ -1,0 +1,12 @@
+import { UploadResponse } from "@actions/artifact";
+import { CheckedOutNode } from "@bc/domain/checkout";
+import { ExecuteNodeResult } from "@bc/domain/execute-node-result";
+import { ExecutionPhase } from "@bc/domain/execution-phase";
+
+export type FlowResult = {
+  checkoutInfo: CheckedOutNode[];
+  artifactUploadResults: PromiseSettledResult<UploadResponse>[];
+  executionResult: {
+    [key in ExecutionPhase]: ExecuteNodeResult[]
+  }
+}

--- a/src/service/flow/flow-service.ts
+++ b/src/service/flow/flow-service.ts
@@ -101,17 +101,17 @@ export class FlowService {
         const current = this.executor.getNodeCommands(node, ExecutionPhase.CURRENT, nodeLevel);
         const after = this.executor.getNodeCommands(node, ExecutionPhase.AFTER, nodeLevel);
 
-        if (before && before.length > 0) {
+        if (before?.length) {
           this.logger.info(`\t [${ExecutionPhase.BEFORE}]`);
           this.logger.info(`\t\t ${before.join("\n")}`);
         }
 
-        if (current && current.length > 0) {
+        if (current?.length) {
           this.logger.info(`\t [${ExecutionPhase.CURRENT}]`);
           this.logger.info(`\t\t ${current.join("\n")}`);
         }
 
-        if (after && after.length > 0) {
+        if (after?.length) {
           this.logger.info(`\t [${ExecutionPhase.AFTER}]`);
           this.logger.info(`\t\t ${after.join("\n")}`);
         }

--- a/src/service/flow/flow-service.ts
+++ b/src/service/flow/flow-service.ts
@@ -41,7 +41,15 @@ export class FlowService {
     this.printCheckoutSummary(checkoutInfo);
     this.logger.endGroup();
 
-    const nodeChainForExecution: NodeExecution[] = checkoutInfo.map((info) => ({ node: info.node, cwd: info.checkoutInfo?.repoDir }));
+    /**
+     * Cannot directly map checkoutInfo into NodeExecution array since the order of nodes might change when parallely checking
+     * out the node chain
+     */
+    const nodeChainForExecution: NodeExecution[] = this.configService.nodeChain.map((node) => {
+      const nodeCheckoutInfo = checkoutInfo.find((info) => info.node.project === node.project);
+      // nodeCheckoutInfo will never be undefined since checkoutInfo is constructed from node chain and so node project will exist
+      return { node, cwd: nodeCheckoutInfo!.checkoutInfo?.repoDir };
+    });
 
     // not looping through the keys of ExecutionPhase just so that we can enforce the order in which the phases need to be executed
     const before = await this.executeAndPrint(nodeChainForExecution, ExecutionPhase.BEFORE);

--- a/src/service/flow/flow-service.ts
+++ b/src/service/flow/flow-service.ts
@@ -1,0 +1,181 @@
+import { UploadResponse } from "@actions/artifact";
+import { CheckedOutNode } from "@bc/domain/checkout";
+import { ExecutionResult } from "@bc/domain/execute-command-result";
+import { ExecuteNodeResult } from "@bc/domain/execute-node-result";
+import { ExecutionPhase } from "@bc/domain/execution-phase";
+import { NodeExecution } from "@bc/domain/node-execution";
+import { ArtifactService } from "@bc/service/artifacts/artifact-service";
+import { CheckoutService } from "@bc/service/checkout/checkout-service";
+import { ExecuteCommandService } from "@bc/service/command/execute-command-service";
+import { ConfigurationService } from "@bc/service/config/configuration-service";
+import { LoggerService } from "@bc/service/logger/logger-service";
+import { LoggerServiceFactory } from "@bc/service/logger/logger-service-factory";
+import Container, { Service } from "typedi";
+
+@Service()
+export class FlowService {
+  private configService: ConfigurationService;
+  private checkoutService: CheckoutService;
+  private executor: ExecuteCommandService;
+  private logger: LoggerService;
+  private artifactService: ArtifactService;
+
+  constructor() {
+    this.configService = Container.get(ConfigurationService);
+    this.checkoutService = Container.get(CheckoutService);
+    this.executor = Container.get(ExecuteCommandService);
+    this.artifactService = Container.get(ArtifactService);
+    this.logger = LoggerServiceFactory.getInstance();
+  }
+
+  async run(): Promise<{
+    checkoutInfo: CheckedOutNode[];
+    artifactUploadResults: PromiseSettledResult<UploadResponse>[];
+    executionResult: {
+      [key in ExecutionPhase]: ExecuteNodeResult[]
+    }
+  }> {
+    const flowType = this.configService.getFlowType();
+    this.logger.startGroup(`[${flowType}] Execution Plan`);
+    this.printExecutionPlan();
+    this.logger.endGroup();
+
+    this.logger.info(`[${flowType}] Checking out ${this.configService.getStarterProjectName()} and its dependencies`);
+    const checkoutInfo = await this.checkoutService.checkoutDefinitionTree();
+
+    this.logger.startGroup(`[${flowType}] Checkout Summary`);
+    this.printCheckoutSummary(checkoutInfo);
+    this.logger.endGroup();
+
+    const nodeChainForExecution: NodeExecution[] = checkoutInfo.map((info) => ({ node: info.node, cwd: info.checkoutInfo?.repoDir }));
+
+    // not looping through the keys of ExecutionPhase just so that we can enforce the order in which the phases need to be executed
+    const before = await this.executeAndPrint(nodeChainForExecution, ExecutionPhase.BEFORE);
+    const commands = await this.executeAndPrint(nodeChainForExecution, ExecutionPhase.CURRENT);
+    const after = await this.executeAndPrint(nodeChainForExecution, ExecutionPhase.AFTER);
+
+    // archive artifacts
+    this.logger.startGroup(`[${flowType}] Uploading artifacts`);
+    const artifactUploadResults = await this.artifactService.uploadNodes(this.configService.nodeChain, this.configService.getStarterNode());
+    this.logger.endGroup();
+
+    return { checkoutInfo, artifactUploadResults, executionResult: {after, commands, before} };
+  }
+
+  /**
+   * Prints the execution plan for the node chain in the following format:
+   *
+   * 3 projects will be executed
+   * [owner/project]
+   *    Level type: current
+   *    [before]
+   *        cmd1
+   *        cmd2
+   *    [command]
+   *        cmd1
+   *    [after]
+   *        cmd1
+   * [abc/xyz]
+   *    Level type: downstream
+   *    No command will be executed (this project will be skipped)
+   * [def/ghi]
+   *    Level type: upstream
+   *    [before]
+   *        cmd1
+   *    [after]
+   *        cmd1
+   */
+  private printExecutionPlan() {
+    this.logger.info(`${this.configService.nodeChain.length} projects will be executed`);
+    this.configService.nodeChain.forEach((node) => {
+      const nodeLevel = this.configService.getNodeExecutionLevel(node);
+      this.logger.info(`[${node.project}]`);
+      this.logger.info(`\t Level type: ${nodeLevel}`);
+
+      if (this.configService.skipExecution(node)) {
+        this.logger.info("\t No command will be executed (this project will be skipped)");
+      } else {
+        const before = this.executor.getNodeCommands(node, ExecutionPhase.BEFORE, nodeLevel);
+        const current = this.executor.getNodeCommands(node, ExecutionPhase.CURRENT, nodeLevel);
+        const after = this.executor.getNodeCommands(node, ExecutionPhase.AFTER, nodeLevel);
+
+        if (before && before.length > 0) {
+          this.logger.info(`\t [${ExecutionPhase.BEFORE}]`);
+          this.logger.info(`\t\t ${before.join("\n")}`);
+        }
+
+        if (current && current.length > 0) {
+          this.logger.info(`\t [${ExecutionPhase.CURRENT}]`);
+          this.logger.info(`\t\t ${current.join("\n")}`);
+        }
+
+        if (after && after.length > 0) {
+          this.logger.info(`\t [${ExecutionPhase.AFTER}]`);
+          this.logger.info(`\t\t ${after.join("\n")}`);
+        }
+      }
+    });
+  }
+
+  /**
+   * Prints the checkout info for the node chain in the following format:
+   *
+   * [owner/project]
+   *    Project taken from owner/project:main
+   *    Merged owner1/project-forked:
+   * [abc/xyz]
+   *    This project wasn't checked out
+   * [def/ghi]
+   *    Project taken from def/ghi:dev
+   */
+  private printCheckoutSummary(checkoutInfo: CheckedOutNode[]) {
+    checkoutInfo.forEach((info) => {
+      this.logger.info(`[${info.node.project}]`);
+      if (info.checkoutInfo) {
+        this.logger.info(`\t Project taken from ${info.checkoutInfo.targetGroup}/${info.checkoutInfo.targetName}:${info.checkoutInfo.targetBranch}`);
+        if (info.checkoutInfo.merge) {
+          this.logger.info(
+            `\t Merged ${info.checkoutInfo.sourceGroup}/${info.checkoutInfo.sourceName}:${info.checkoutInfo.sourceBranch} into branch ${info.checkoutInfo.targetBranch}`
+          );
+        }
+      } else {
+        this.logger.info("\t This project wasn't checked out");
+      }
+    });
+  }
+
+  /**
+   * Prints the checkout info for the node chain in the following format:
+   *
+   * [owner/project]
+   *    [OK] cmd1 [Executed in: 10s]
+   * [abc/xyz]
+   *    No commands were found for this project
+   * [def/ghi]
+   *    [NOT_OK] cmd2 [Executed in: 5s]
+   *        Error: msg
+   */
+  private printExecutionSummary(result: ExecuteNodeResult[]) {
+    result.forEach((res) => {
+      this.logger.info(`[${res.node.project}]`);
+      if (res.executeCommandResults.length === 0) {
+        this.logger.info("\t No commands were found for this project");
+      }
+      res.executeCommandResults.forEach((cmdRes) => {
+        this.logger.info(`\t [${cmdRes.result}] ${cmdRes.command} [Executed in ${cmdRes.time} ms]`);
+        if (cmdRes.result === ExecutionResult.NOT_OK) {
+          this.logger.info(`\t\t Error: ${cmdRes.errorMessage}`);
+        }
+      });
+    });
+  }
+
+  private async executeAndPrint(chain: NodeExecution[], phase: ExecutionPhase): Promise<ExecuteNodeResult[]> {
+    this.logger.info(`[${this.configService.getFlowType()}] Executing ${phase}`);
+    const result = await this.executor.executeChainCommands(chain, phase);
+    this.logger.startGroup(`Execution summary for phase ${phase}`);
+    this.printExecutionSummary(result);
+    this.logger.endGroup();
+    return result;
+  }
+}

--- a/src/service/flow/flow-service.ts
+++ b/src/service/flow/flow-service.ts
@@ -3,6 +3,7 @@ import { CheckedOutNode } from "@bc/domain/checkout";
 import { ExecutionResult } from "@bc/domain/execute-command-result";
 import { ExecuteNodeResult } from "@bc/domain/execute-node-result";
 import { ExecutionPhase } from "@bc/domain/execution-phase";
+import { FlowResult } from "@bc/domain/flow";
 import { NodeExecution } from "@bc/domain/node-execution";
 import { ArtifactService } from "@bc/service/artifacts/artifact-service";
 import { CheckoutService } from "@bc/service/checkout/checkout-service";
@@ -28,13 +29,7 @@ export class FlowService {
     this.logger = LoggerServiceFactory.getInstance();
   }
 
-  async run(): Promise<{
-    checkoutInfo: CheckedOutNode[];
-    artifactUploadResults: PromiseSettledResult<UploadResponse>[];
-    executionResult: {
-      [key in ExecutionPhase]: ExecuteNodeResult[]
-    }
-  }> {
+  async run(): Promise<FlowResult> {
     const flowType = this.configService.getFlowType();
     this.logger.startGroup(`[${flowType}] Execution Plan`);
     this.printExecutionPlan();

--- a/src/service/flow/flow-service.ts
+++ b/src/service/flow/flow-service.ts
@@ -1,4 +1,3 @@
-import { UploadResponse } from "@actions/artifact";
 import { CheckedOutNode } from "@bc/domain/checkout";
 import { ExecutionResult } from "@bc/domain/execute-command-result";
 import { ExecuteNodeResult } from "@bc/domain/execute-node-result";

--- a/test/unitary/service/flow/flow-service.test.ts
+++ b/test/unitary/service/flow/flow-service.test.ts
@@ -1,0 +1,225 @@
+import "reflect-metadata";
+import { UploadResponse } from "@actions/artifact";
+import { CheckedOutNode } from "@bc/domain/checkout";
+import { constants } from "@bc/domain/constants";
+import { EntryPoint } from "@bc/domain/entry-point";
+import { ExecutionResult } from "@bc/domain/execute-command-result";
+import { ExecuteNodeResult } from "@bc/domain/execute-node-result";
+import { ExecutionPhase } from "@bc/domain/execution-phase";
+import { FlowType } from "@bc/domain/inputs";
+import { Node } from "@bc/domain/node";
+import { NodeExecutionLevel } from "@bc/domain/node-execution";
+import { CheckoutService } from "@bc/service/checkout/checkout-service";
+import { ExecuteCommandService } from "@bc/service/command/execute-command-service";
+import { ConfigurationService } from "@bc/service/config/configuration-service";
+import { FlowService } from "@bc/service/flow/flow-service";
+import { GithubActionLoggerService } from "@bc/service/logger/github-action-logger-service";
+import Container from "typedi";
+import { ArtifactService } from "@bc/service/artifacts/artifact-service";
+
+const nodeChain: Node[] = [
+  {
+    project: "owner1/project1",
+    before: {
+      upstream: ["cmd1"],
+      downstream: [],
+      current: [],
+    },
+  },
+  {
+    project: "owner2/project2",
+    before: {
+      current: ["cmd2-before"],
+      downstream: [],
+      upstream: [],
+    },
+    commands: {
+      upstream: [],
+      downstream: [],
+      current: ["cmd2-current"],
+    },
+    after: {
+      upstream: [],
+      downstream: [],
+      current: [],
+    },
+  },
+  {
+    project: "owner3/project3",
+    after: {
+      upstream: [],
+      downstream: [],
+      current: ["cmd3"],
+    },
+    commands: {
+      upstream: [],
+      downstream: [],
+      current: [],
+    },
+  },
+];
+
+const checkoutInfo: CheckedOutNode[] = [
+  {
+    node: nodeChain[0],
+  },
+  {
+    node: nodeChain[1],
+    checkoutInfo: {
+      sourceBranch: "main",
+      sourceGroup: "owner2",
+      sourceName: "project2",
+      targetBranch: "main",
+      targetGroup: "owner2",
+      targetName: "project2",
+      merge: false,
+      repoDir: "owner2_project2",
+    },
+  },
+  {
+    node: nodeChain[2],
+    checkoutInfo: {
+      sourceBranch: "dev",
+      sourceGroup: "owner3-forked",
+      sourceName: "project3-forked",
+      targetBranch: "main",
+      targetGroup: "owner3",
+      targetName: "project3",
+      merge: true,
+      repoDir: "owner3_project3",
+    },
+  },
+];
+
+const executionResult: ExecuteNodeResult[] = [
+  {
+    node: nodeChain[0],
+    executeCommandResults: [],
+  },
+  {
+    node: nodeChain[1],
+    executeCommandResults: [
+      {
+        startingDate: 0,
+        endingDate: 2,
+        time: 2,
+        command: "cmd2",
+        result: ExecutionResult.OK,
+        errorMessage: "",
+      },
+    ],
+  },
+  {
+    node: nodeChain[2],
+    executeCommandResults: [
+      {
+        startingDate: 0,
+        endingDate: 3,
+        time: 3,
+        command: "cmd3",
+        result: ExecutionResult.NOT_OK,
+        errorMessage: "error",
+      },
+    ],
+  },
+];
+
+const artifactUploadResults: PromiseSettledResult<UploadResponse>[] = [];
+
+test("run flow", async () => {
+  // entry point does not make any difference for this function
+  Container.set(constants.CONTAINER.ENTRY_POINT, EntryPoint.GITHUB_EVENT);
+
+  // flow type does not make a difference for this function
+  const flowType = FlowType.BRANCH;
+  jest.spyOn(ConfigurationService.prototype, "getFlowType").mockImplementation(() => flowType);
+
+  jest.spyOn(ConfigurationService.prototype, "nodeChain", "get").mockImplementation(() => nodeChain);
+  jest.spyOn(ConfigurationService.prototype, "getStarterProjectName").mockImplementation(() => nodeChain[1].project);
+  jest.spyOn(ConfigurationService.prototype, "getStarterNode").mockImplementation(() => nodeChain[1]);
+  jest
+    .spyOn(ConfigurationService.prototype, "skipExecution")
+    .mockImplementationOnce(() => true)
+    .mockImplementationOnce(() => false)
+    .mockImplementationOnce(() => false);
+  jest.spyOn(CheckoutService.prototype, "checkoutDefinitionTree").mockImplementation(async () => checkoutInfo);
+  jest.spyOn(ExecuteCommandService.prototype, "executeChainCommands").mockImplementation(async () => executionResult);
+  jest.spyOn(ArtifactService.prototype, "uploadNodes").mockImplementation(async () => []);
+
+  const groupSpy = jest.spyOn(GithubActionLoggerService.prototype, "startGroup").mockImplementation((_msg) => undefined);
+  jest.spyOn(GithubActionLoggerService.prototype, "endGroup").mockImplementation(() => undefined);
+  jest.spyOn(GithubActionLoggerService.prototype, "debug").mockImplementation((_msg) => undefined);
+  const infoSpy = jest.spyOn(GithubActionLoggerService.prototype, "info").mockImplementation((_msg) => undefined);
+
+  const flowService = Container.get(FlowService);
+  const result = await flowService.run();
+
+  // execution plan
+  expect(groupSpy).toHaveBeenNthCalledWith(1, `[${flowType}] Execution Plan`);
+  expect(infoSpy).toHaveBeenNthCalledWith(1, `${nodeChain.length} projects will be executed`);
+  expect(infoSpy).toHaveBeenNthCalledWith(2, `[${nodeChain[0].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(3, `\t Level type: ${NodeExecutionLevel.UPSTREAM}`);
+  expect(infoSpy).toHaveBeenNthCalledWith(4, "\t No command will be executed (this project will be skipped)");
+  expect(infoSpy).toHaveBeenNthCalledWith(5, `[${nodeChain[1].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(6, `\t Level type: ${NodeExecutionLevel.CURRENT}`);
+  expect(infoSpy).toHaveBeenNthCalledWith(7, `\t [${ExecutionPhase.BEFORE}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(8, "\t\t cmd2-before");
+  expect(infoSpy).toHaveBeenNthCalledWith(9, `\t [${ExecutionPhase.CURRENT}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(10, "\t\t cmd2-current");
+  expect(infoSpy).toHaveBeenNthCalledWith(11, `[${nodeChain[2].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(12, `\t Level type: ${NodeExecutionLevel.DOWNSTREAM}`);
+  expect(infoSpy).toHaveBeenNthCalledWith(13, `\t [${ExecutionPhase.AFTER}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(14, "\t\t cmd3");
+
+  // checkout summary
+  expect(infoSpy).toHaveBeenNthCalledWith(15, `[${flowType}] Checking out ${nodeChain[1].project} and its dependencies`);
+  expect(groupSpy).toHaveBeenNthCalledWith(2, `[${flowType}] Checkout Summary`);
+  expect(infoSpy).toHaveBeenNthCalledWith(16, `[${nodeChain[0].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(17, "\t This project wasn't checked out");
+  expect(infoSpy).toHaveBeenNthCalledWith(18, `[${nodeChain[1].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(19, "\t Project taken from owner2/project2:main");
+  expect(infoSpy).toHaveBeenNthCalledWith(20, `[${nodeChain[2].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(21, "\t Project taken from owner3/project3:main");
+  expect(infoSpy).toHaveBeenNthCalledWith(22, "\t Merged owner3-forked/project3-forked:dev into branch main");
+
+  // execution summary: BEFORE
+  expect(infoSpy).toHaveBeenNthCalledWith(23, `[${flowType}] Executing ${ExecutionPhase.BEFORE}`);
+  expect(groupSpy).toHaveBeenNthCalledWith(3, `Execution summary for phase ${ExecutionPhase.BEFORE}`);
+  expect(infoSpy).toHaveBeenNthCalledWith(24, `[${nodeChain[0].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(25, "\t No commands were found for this project");
+  expect(infoSpy).toHaveBeenNthCalledWith(26, `[${nodeChain[1].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(27, `\t [${ExecutionResult.OK}] cmd2 [Executed in 2 ms]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(28, `[${nodeChain[2].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(29, `\t [${ExecutionResult.NOT_OK}] cmd3 [Executed in 3 ms]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(30, "\t\t Error: error");
+
+  // execution summary: CURRENT
+  expect(infoSpy).toHaveBeenNthCalledWith(31, `[${flowType}] Executing ${ExecutionPhase.CURRENT}`);
+  expect(groupSpy).toHaveBeenNthCalledWith(4, `Execution summary for phase ${ExecutionPhase.CURRENT}`);
+  expect(infoSpy).toHaveBeenNthCalledWith(32, `[${nodeChain[0].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(33, "\t No commands were found for this project");
+  expect(infoSpy).toHaveBeenNthCalledWith(34, `[${nodeChain[1].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(35, `\t [${ExecutionResult.OK}] cmd2 [Executed in 2 ms]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(36, `[${nodeChain[2].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(37, `\t [${ExecutionResult.NOT_OK}] cmd3 [Executed in 3 ms]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(38, "\t\t Error: error");
+
+  // execution summary: AFTER
+  expect(infoSpy).toHaveBeenNthCalledWith(39, `[${flowType}] Executing ${ExecutionPhase.AFTER}`);
+  expect(groupSpy).toHaveBeenNthCalledWith(5, `Execution summary for phase ${ExecutionPhase.AFTER}`);
+  expect(infoSpy).toHaveBeenNthCalledWith(40, `[${nodeChain[0].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(41, "\t No commands were found for this project");
+  expect(infoSpy).toHaveBeenNthCalledWith(42, `[${nodeChain[1].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(43, `\t [${ExecutionResult.OK}] cmd2 [Executed in 2 ms]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(44, `[${nodeChain[2].project}]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(45, `\t [${ExecutionResult.NOT_OK}] cmd3 [Executed in 3 ms]`);
+  expect(infoSpy).toHaveBeenNthCalledWith(46, "\t\t Error: error");
+
+  expect(groupSpy).toHaveBeenNthCalledWith(6, `[${flowType}] Uploading artifacts`);
+
+  expect(result).toStrictEqual({
+    checkoutInfo,
+    artifactUploadResults,
+    executionResult: { before: executionResult, after: executionResult, commands: executionResult },
+  });
+});


### PR DESCRIPTION
Fixes #255 

Due to the way how our other services are designed, we didn't really need a complex flow class design. The difference between each flow (at least from what I saw in `main` branch) is how the node chain is constructed. Node chain construction for different flows was already covered in config service.

Because the complexity of flow service has reduced by a quite a lot, I dont think we require a `FlowHelperService` and so we can close #253 if you agree @Ginxo 
