### PR TITLE
CLI argument parsing bug fix

### DIFF
--- a/src/bin/entry-point/cli.ts
+++ b/src/bin/entry-point/cli.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { CLIRunner } from "@bc/bin/runners/cli-runner";
 
 new CLIRunner().execute();

--- a/src/bin/runners/cli-runner.ts
+++ b/src/bin/runners/cli-runner.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import "reflect-metadata";
 import { Runner } from "@bc/bin/runners/runner";
 import { EntryPoint } from "@bc/domain/entry-point";

--- a/src/bin/runners/github-action-runner.ts
+++ b/src/bin/runners/github-action-runner.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import "reflect-metadata";
 import { Runner } from "@bc/bin/runners/runner";
 import { EntryPoint } from "@bc/domain/entry-point";

--- a/src/service/arguments/cli/build/abstract-pr-command.ts
+++ b/src/service/arguments/cli/build/abstract-pr-command.ts
@@ -13,7 +13,7 @@ export abstract class AbstractPullRequestCommand implements CommandConstructor {
   }
 
   createCommand(): Command {
-    return new Command(`${CLIActionType.BUILD} ${this.type}`)
+    return new Command(this.type)
       .description(this.description)
       .requiredOption("-u, --url <event_url>", "pull request event url")
       .option("-p, --startProject <project>", "The project to start the build from");

--- a/src/service/arguments/cli/build/branch-command.ts
+++ b/src/service/arguments/cli/build/branch-command.ts
@@ -9,7 +9,7 @@ import { FlowType } from "@bc/domain/inputs";
  */
 export class BranchCommand implements CommandConstructor {
   createCommand(): Command {
-    const program = new Command(`${CLIActionType.BUILD} ${FlowType.BRANCH}`);
+    const program = new Command(FlowType.BRANCH);
     program
       .description("Execute branch build chain workflow")
       .requiredOption("-p, --startProject <project>", "The project to start the build from")

--- a/src/service/arguments/cli/cli-arguments.ts
+++ b/src/service/arguments/cli/cli-arguments.ts
@@ -1,3 +1,4 @@
+import { CLIActionType } from "@bc/domain/cli";
 import { BuildSubCommandFactory } from "@bc/service/arguments/cli/build/build-subcommand-factory";
 import { ToolSubCommandFactory } from "@bc/service/arguments/cli/tools/tool-subcommand-factory";
 import { Command } from "commander";
@@ -18,10 +19,16 @@ export class CLIArguments {
 
     program.name("build-chain").description("A CLI tool to perform the build chain github actions");
 
-    BuildSubCommandFactory.getAllCommands().forEach(cmd => program.addCommand(this.setConfig(cmd, options)));
-    ToolSubCommandFactory.getAllCommands().forEach(cmd => program.addCommand(this.setConfig(cmd, options)));
+    const buildSubProgram = new Command(CLIActionType.BUILD).description("Execute different flows");
+    const toolSubProgram = new Command(CLIActionType.TOOLS).description("A bunch of utility tools");
 
-    return this.setConfig(program, options);
+    BuildSubCommandFactory.getAllCommands().forEach(cmd => buildSubProgram.addCommand(this.setConfig(cmd, options)));
+    ToolSubCommandFactory.getAllCommands().forEach(cmd => toolSubProgram.addCommand(this.setConfig(cmd, options)));
+
+    program.addCommand(buildSubProgram);
+    program.addCommand(toolSubProgram);
+
+    return program;
   }
 
   /**

--- a/src/service/arguments/cli/tools/project-list.ts
+++ b/src/service/arguments/cli/tools/project-list.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { CommandConstructor } from "@bc/service/arguments/cli/command-constructor";
-import { CLIActionType, ToolType } from "@bc/domain/cli";
+import { ToolType } from "@bc/domain/cli";
 
 /**
  * Create command parser for project list tool
@@ -8,7 +8,7 @@ import { CLIActionType, ToolType } from "@bc/domain/cli";
  */
 export class ProjectListCommand implements CommandConstructor {
   createCommand(): Command {
-    const program = new Command(`${CLIActionType.TOOLS} ${ToolType.PROJECT_LIST}`);
+    const program = new Command(ToolType.PROJECT_LIST);
     program
       .description("Prints a ordered  by precendence list of projects")
       .option("-s, --skipGroup <group_names...>", "Remove group from project list");

--- a/test/unitary/service/arguments/cli/build-branch.test.ts
+++ b/test/unitary/service/arguments/cli/build-branch.test.ts
@@ -15,7 +15,7 @@ const definitionFile = "/path/to/file";
 const branch = "main";
 
 // command to be executed
-const command = `${CLIActionType.BUILD} ${FlowType.BRANCH}`;
+const command = [CLIActionType.BUILD, FlowType.BRANCH];
 const parsedInputs = Container.get(InputService);
 
 beforeEach(() => {
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 describe("build branch flow cli", () => {
   test("only required options", () => {
-    program.parse([command, "-f", definitionFile, "-p", startProject, "-b", branch], { from: "user" });
+    program.parse([...command, "-f", definitionFile, "-p", startProject, "-b", branch], { from: "user" });
 
     // check all the required options are set and all the optional ones have the right default value if any
     const option = parsedInputs.inputs;
@@ -46,9 +46,9 @@ describe("build branch flow cli", () => {
 
   // check for missing required options
   test.each([
-    ["definition file", [command, "-p", startProject, "-b", branch]],
-    ["starting project", [command, "-f", definitionFile, "-b", branch]],
-    ["branch", [command, "-f", definitionFile, "-p", startProject]],
+    ["definition file", [...command, "-p", startProject, "-b", branch]],
+    ["starting project", [...command, "-f", definitionFile, "-b", branch]],
+    ["branch", [...command, "-f", definitionFile, "-p", startProject]],
   ])("missing %p", (title: string, cmd: string[]) => {
     try {
       program.parse(cmd, { from: "user" });
@@ -70,7 +70,7 @@ describe("build branch flow cli", () => {
 
     program.parse(
       [
-        command,
+        ...command,
         "-f",
         definitionFile,
         "-p",

--- a/test/unitary/service/arguments/cli/build-cross_pr.test.ts
+++ b/test/unitary/service/arguments/cli/build-cross_pr.test.ts
@@ -14,7 +14,7 @@ const url = "test.com";
 const definitionFile = "/path/to/file";
 
 // Command to be executed
-const command = `${CLIActionType.BUILD} ${FlowType.CROSS_PULL_REQUEST}`;
+const command = [CLIActionType.BUILD, FlowType.CROSS_PULL_REQUEST];
 const parsedInputs = Container.get(InputService);
 
 beforeEach(() => {
@@ -24,7 +24,7 @@ beforeEach(() => {
 
 describe("build cross pull request flow cli", () => {
   test("only required options", () => {
-    program.parse([command, "-f", definitionFile, "-u", url], { from: "user" });
+    program.parse([...command, "-f", definitionFile, "-u", url], { from: "user" });
 
     // check all the required options are set and all the optional ones have the right default value if any
     const option = parsedInputs.inputs;
@@ -43,8 +43,8 @@ describe("build cross pull request flow cli", () => {
 
   // check for missing required options
   test.each([
-    ["definition file", [command, "-u", url]],
-    ["url", [command, "-f", definitionFile]],
+    ["definition file", [...command, "-u", url]],
+    ["url", [...command, "-f", definitionFile]],
   ])("missing %p", (title: string, cmd: string[]) => {
     try {
       program.parse(cmd, { from: "user" });
@@ -65,7 +65,7 @@ describe("build cross pull request flow cli", () => {
 
     program.parse(
       [
-        command,
+        ...command,
         "-f",
         definitionFile,
         "-u",

--- a/test/unitary/service/arguments/cli/build-fd.test.ts
+++ b/test/unitary/service/arguments/cli/build-fd.test.ts
@@ -14,7 +14,7 @@ const url = "test.com";
 const definitionFile = "/path/to/file";
 
 // Command to be executed
-const command = `${CLIActionType.BUILD} ${FlowType.FULL_DOWNSTREAM}`;
+const command = [CLIActionType.BUILD, FlowType.FULL_DOWNSTREAM];
 const parsedInputs = Container.get(InputService);
 
 beforeEach(() => {
@@ -24,7 +24,7 @@ beforeEach(() => {
 
 describe("build full downstream pull request flow cli", () => {
   test("only required options", () => {
-    program.parse([command, "-f", definitionFile, "-u", url], { from: "user" });
+    program.parse([...command, "-f", definitionFile, "-u", url], { from: "user" });
 
     // check all the required options are set and all the optional ones have the right default value if any
     const option = parsedInputs.inputs;
@@ -43,8 +43,8 @@ describe("build full downstream pull request flow cli", () => {
 
   // check for missing required options
   test.each([
-    ["definition file", [command, "-u", url]],
-    ["url", [command, "-f", definitionFile]],
+    ["definition file", [...command, "-u", url]],
+    ["url", [...command, "-f", definitionFile]],
   ])("missing %p", (title: string, cmd: string[]) => {
     try {
       program.parse(cmd, { from: "user" });
@@ -65,7 +65,7 @@ describe("build full downstream pull request flow cli", () => {
 
     program.parse(
       [
-        command,
+        ...command,
         "-f",
         definitionFile,
         "-u",

--- a/test/unitary/service/arguments/cli/build-single.test.ts
+++ b/test/unitary/service/arguments/cli/build-single.test.ts
@@ -14,7 +14,7 @@ const url = "test.com";
 const definitionFile = "/path/to/file";
 
 // Command to be executed
-const command = `${CLIActionType.BUILD} ${FlowType.SINGLE_PULL_REQUEST}`;
+const command = [CLIActionType.BUILD, FlowType.SINGLE_PULL_REQUEST];
 const parsedInputs = Container.get(InputService);
 
 beforeEach(() => {
@@ -24,7 +24,7 @@ beforeEach(() => {
 
 describe("build single pull request flow cli", () => {
   test("only required options", () => {
-    program.parse([command, "-f", definitionFile, "-u", url], { from: "user" });
+    program.parse([...command, "-f", definitionFile, "-u", url], { from: "user" });
 
     // check all the required options are set and all the optional ones have the right default value if any
     const option = parsedInputs.inputs;
@@ -43,8 +43,8 @@ describe("build single pull request flow cli", () => {
 
   // check for missing required options
   test.each([
-    ["definition file", [command, "-u", url]],
-    ["url", [command, "-f", definitionFile]],
+    ["definition file", [...command, "-u", url]],
+    ["url", [...command, "-f", definitionFile]],
   ])("missing %p", (title: string, cmd: string[]) => {
     try {
       program.parse(cmd, { from: "user" });
@@ -65,7 +65,7 @@ describe("build single pull request flow cli", () => {
 
     program.parse(
       [
-        command,
+        ...command,
         "-f",
         definitionFile,
         "-u",

--- a/test/unitary/service/arguments/cli/tool-project_list.test.ts
+++ b/test/unitary/service/arguments/cli/tool-project_list.test.ts
@@ -9,7 +9,7 @@ import { LoggerLevel } from "@bc/domain/inputs";
 let program: Command;
 
 // Command to be executed
-const command = `${CLIActionType.TOOLS} ${ToolType.PROJECT_LIST}`;
+const command = [CLIActionType.TOOLS, ToolType.PROJECT_LIST];
 
 // Define required arguments to be reused for each test
 const definitionFile = "/path/to/file";
@@ -22,7 +22,7 @@ beforeEach(() => {
 
 describe("build single pull request flow cli", () => {
   test("only required options", () => {
-    program.parse([command, "-f", definitionFile], { from: "user" });
+    program.parse([...command, "-f", definitionFile], { from: "user" });
 
     // check all the required options are set and all the optional ones have the right default value if any
     const option = parsedInputs.inputs;
@@ -35,9 +35,9 @@ describe("build single pull request flow cli", () => {
   });
 
   // check for missing required options
-  test.each([["definition file", [command]]])("missing %p", (title: string, cmd: string[]) => {
+  test("missing definition file", () => {
     try {
-      program.parse(cmd, { from: "user" });
+      program.parse(command, { from: "user" });
     } catch (err) {
       expect(err).toBeInstanceOf(CommanderError);
       if (err instanceof CommanderError) {
@@ -50,7 +50,7 @@ describe("build single pull request flow cli", () => {
     const skipGroup = ["gr1", "gr2"];
     const token = "abc";
 
-    program.parse([command, "-f", definitionFile, "--token", token, "-s", ...skipGroup, "-d"], { from: "user" });
+    program.parse([...command, "-f", definitionFile, "--token", token, "-s", ...skipGroup, "-d"], { from: "user" });
 
     // check all the required options and optional options are set correctly
     const option = parsedInputs.inputs;


### PR DESCRIPTION
The cli argument parser for parsing the sub-commands to be 1 word so something like this:
```
build-chain 'build cross_pr'
```
and would fail if we did something like this
```
build-chain build cross_pr
```

This PR fixes that and now the parsing should work as expected