### PR TITLE
removed hard coded version from job summary tests

### DIFF
--- a/test/unitary/service/job-summary/expected-summary
+++ b/test/unitary/service/job-summary/expected-summary
@@ -45,7 +45,7 @@ flowchart LR;
 <details open><summary><h2>Post</h2></summary><table><tr><th>Command</th><th>Execution Result</th><th>Execution Time</th></tr><tr><td>cmd1</td><td>✅</td><td>1</td></tr><tr><td>cmd2</td><td>❌</td><td>2</td></tr><tr><td>cmd3</td><td>✅</td><td>3</td></tr></table>
 </details>
 <details open><summary><h2>Local Execution</h2></summary>You can copy paste the following commands to locally execute build chain tool.
-<pre><code>npm i @kie/build-chain-action@3.0.3 -g build-chain-action -f definitionFile build cross_pr -u eventUrl</code></pre>
+<pre><code>npm i ${{ PACKAGE_NAME_AND_VERSION }} -g build-chain-action -f definitionFile build cross_pr -u eventUrl</code></pre>
 
 **Git Version**: `1.0.1`
 > **_Notice_**: The `GITHUB_TOKEN` should be set in the environment.

--- a/test/unitary/service/job-summary/job-summary-service.test.ts
+++ b/test/unitary/service/job-summary/job-summary-service.test.ts
@@ -198,8 +198,15 @@ test("non-branch flow", async () => {
     prePostResult,
     prePostResult
   );
-
-  expect(readFileSync(filename, "utf8")).toBe(readFileSync(path.join(__dirname, "expected-summary"), "utf8"));
+  
+  const expected = readFileSync(
+    path.join(__dirname, "expected-summary"),
+    "utf8"
+  ).replace(
+    /\${{ PACKAGE_NAME_AND_VERSION }}/,
+    `${process.env.npm_package_name}@${process.env.npm_package_version}`
+  );
+  expect(readFileSync(filename, "utf8")).toBe(expected);
 });
 
 test("branch flow", async () => {


### PR DESCRIPTION
Fixes #334 

Removed hardcoded version number from expected output since job summary uses the current package version to produce the markdown file. This was annoying since anytime we wanted to release a new version we had to update this file