### PR TITLE
automate action publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,10 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run build
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "publish latest dist/index.js"
+          file_pattern: "dist"
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Fixes #339 

The goal is not to rely on developers to update `dist/index.js` in their PRs.
This PR will build `dist/index.js` and commit it to this repository