### PR TITLE
speed up e2e by running the tests parallelly

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:build": "tsc && tsc-alias",
     "test": "jest unitary/",
     "pretest:e2e": "ncc build -o dist-e2e --minify src/bin/entry-point/github-action.ts",
-    "test:e2e": "jest --runInBand e2e/",
+    "test:e2e": "jest e2e/",
     "posttest:e2e": "rm -rf dist-e2e",
     "test:report": "npm test -- --coverage --testResultsProcessor=jest-sonar-reporter",
     "lint": "eslint . --ext .ts",

--- a/test/e2e/branch/branch.yaml
+++ b/test/e2e/branch/branch.yaml
@@ -1,4 +1,4 @@
-name: push checks
+name: Branch
 
 on: push
 jobs:

--- a/test/e2e/cross-pr/cross-pr.yaml
+++ b/test/e2e/cross-pr/cross-pr.yaml
@@ -1,4 +1,4 @@
-name: Pull request checks
+name: Cross PR
 
 on: pull_request
 jobs:

--- a/test/e2e/full-downstream/full-downstream.yaml
+++ b/test/e2e/full-downstream/full-downstream.yaml
@@ -1,4 +1,4 @@
-name: Pull request checks
+name: Full Downstream
 
 on: pull_request
 jobs:

--- a/test/e2e/single-pr/single-pr.yaml
+++ b/test/e2e/single-pr/single-pr.yaml
@@ -1,4 +1,4 @@
-name: Pull request checks
+name: Single PR
 
 on: pull_request
 jobs:


### PR DESCRIPTION
e2e tests take about 80 seconds or more currently as we had to run them sequentially. This was because when we would run the tests parallelly `act` would error out and say `volume already in use`. 

However after some investigating it seems like the naming convention followed by `act` for volumes and containers is `act-WORKFLOW_NAME-JOB_ID`. 

So simply changing the workflow names has allowed us to run the tests parallelly reducing the run time by 75%