### PR TITLE
bug fix: didn't pass options while generating node chain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/src/service/config/definition-file-reader.ts
+++ b/src/service/config/definition-file-reader.ts
@@ -53,7 +53,8 @@ export class DefinitionFileReader {
       case FlowType.CROSS_PULL_REQUEST: {
         const node = await getTreeForProject(
           this.configuration.parsedInputs.definitionFile,
-          starterProject
+          starterProject,
+          options
         );
         if (!node) {
           throw new Error("Starting project not found");


### PR DESCRIPTION
Forgot to pass `options` to `generateNodeChain` during `CROSS_PULL_REQUEST` flow causing invalid definition file url.
For example this url would fail in a cross_pr flow:
`https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml`