### PR TITLE
Add getting definition file using only default value of placeholders and improve error logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.0.10",
+      "version": "3.0.11",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/src/bin/runners/cli-runner.ts
+++ b/src/bin/runners/cli-runner.ts
@@ -10,32 +10,36 @@ export class CLIRunner extends Runner {
   }
 
   async execute(): Promise<void> {
-    // parse arguments
-    const args = Container.get(CLIArguments);
-    args.getCommand().parse();
+    try {
+      // parse arguments
+      const args = Container.get(CLIArguments);
+      args.getCommand().parse();
 
-    // initialize configuration
-    await this.initConfiguration();
+      // initialize configuration
+      await this.initConfiguration();
 
-    // execute pre section
-    const preResult = await this.executePre();
-    if (preResult.isFailure) {
-      this.printExecutionFailure(preResult.output);
-      return process.exit(1);
-    }
+      // execute pre section
+      const preResult = await this.executePre();
+      if (preResult.isFailure) {
+        this.printExecutionFailure(preResult.output);
+        return process.exit(1);
+      }
 
-    // execute flow: checkout node chain -> execute commands for each phase -> upload artifacts
-    const flowResult = await this.executeFlow();
+      // execute flow: checkout node chain -> execute commands for each phase -> upload artifacts
+      const flowResult = await this.executeFlow();
 
-    // execute post section
-    const postResult = await this.executePost(flowResult.isFailure);
+      // execute post section
+      const postResult = await this.executePost(flowResult.isFailure);
 
-    if (flowResult.isFailure || postResult.isFailure) {
-      this.printNodeExecutionFailure(flowResult.output.executionResult.before);
-      this.printNodeExecutionFailure(flowResult.output.executionResult.commands);
-      this.printNodeExecutionFailure(flowResult.output.executionResult.after);
-      this.printExecutionFailure(postResult.output);
-      return process.exit(1);
+      if (flowResult.isFailure || postResult.isFailure) {
+        this.printNodeExecutionFailure(flowResult.output.executionResult.before);
+        this.printNodeExecutionFailure(flowResult.output.executionResult.commands);
+        this.printNodeExecutionFailure(flowResult.output.executionResult.after);
+        this.printExecutionFailure(postResult.output);
+        return process.exit(1);
+      }
+    } catch (err) {
+      process.exit(1);
     }
   }
 }

--- a/src/bin/runners/github-action-runner.ts
+++ b/src/bin/runners/github-action-runner.ts
@@ -12,44 +12,48 @@ export class GithubActionRunner extends Runner {
   }
 
   async execute(): Promise<void> {
-    // parse arguments
-    const args = Container.get(ActionArguments);
-    args.parse();
+    try {
+      // parse arguments
+      const args = Container.get(ActionArguments);
+      args.parse();
 
-    // initialize configuration
-    await this.initConfiguration();
+      // initialize configuration
+      await this.initConfiguration();
 
-    const jobSummaryService = Container.get(JobSummaryService);
+      const jobSummaryService = Container.get(JobSummaryService);
 
-    // execute pre section
-    const preResult = await this.executePre();
-    if (preResult.isFailure) {
+      // execute pre section
+      const preResult = await this.executePre();
+      if (preResult.isFailure) {
+        // io task is involved so start it as a promise and wait for it when actually needed
+        const promise = jobSummaryService.generateSummary(defaultFlowResult, preResult.output, []);
+        this.printExecutionFailure(preResult.output);
+        await promise;
+        return process.exit(1);
+      }
+
+      // execute flow: checkout node chain -> execute commands for each phase -> upload artifacts
+      const flowResult = await this.executeFlow();
+
+      // execute post section
+      const postResult = await this.executePost(flowResult.isFailure);
+
+      // post a job summary
       // io task is involved so start it as a promise and wait for it when actually needed
-      const promise = jobSummaryService.generateSummary(defaultFlowResult, preResult.output, []);
-      this.printExecutionFailure(preResult.output);
+      const promise = jobSummaryService.generateSummary(flowResult.output, preResult.output, postResult.output);
+
+      if (flowResult.isFailure || postResult.isFailure) {
+        this.printNodeExecutionFailure(flowResult.output.executionResult.before);
+        this.printNodeExecutionFailure(flowResult.output.executionResult.commands);
+        this.printNodeExecutionFailure(flowResult.output.executionResult.after);
+        this.printExecutionFailure(postResult.output);
+        await promise;
+        return process.exit(1);
+      }
+
       await promise;
-      return process.exit(1);
+    } catch (err) {
+      process.exit(1);
     }
-
-    // execute flow: checkout node chain -> execute commands for each phase -> upload artifacts
-    const flowResult = await this.executeFlow();
-
-    // execute post section
-    const postResult = await this.executePost(flowResult.isFailure);
-
-    // post a job summary
-    // io task is involved so start it as a promise and wait for it when actually needed
-    const promise = jobSummaryService.generateSummary(flowResult.output, preResult.output, postResult.output);
-
-    if (flowResult.isFailure || postResult.isFailure) {
-      this.printNodeExecutionFailure(flowResult.output.executionResult.before);
-      this.printNodeExecutionFailure(flowResult.output.executionResult.commands);
-      this.printNodeExecutionFailure(flowResult.output.executionResult.after);
-      this.printExecutionFailure(postResult.output);
-      await promise;
-      return process.exit(1);
-    }
-
-    await promise;
   }
 }

--- a/src/service/config/definition-file-reader.ts
+++ b/src/service/config/definition-file-reader.ts
@@ -109,7 +109,19 @@ export class DefinitionFileReader {
         }
       );
     } catch (err) {
-      logAndThrow("Invalid definition file");
+      this.logger.debug(
+        "Did not find correct definition file, trying with default placeholder values"
+      );
+    }
+
+    try {
+      return await readDefinitionFile(
+        this.configuration.parsedInputs.definitionFile, { 
+          token: Container.get(constants.GITHUB.TOKEN)
+        }
+      );
+    } catch(err) {
+      logAndThrow(`Invalid definition file. ${err}`);
     }
   }
 
@@ -131,7 +143,17 @@ export class DefinitionFileReader {
         token: Container.get(constants.GITHUB.TOKEN),
       });
     } catch (err) {
-      logAndThrow("Invalid definition file");
+      this.logger.debug(
+        "Did not find correct definition file, trying with default placeholder values"
+      );
+    }
+
+    try {
+      return await this.generateNodeChainWithOptions(starterProject, {
+        token: Container.get(constants.GITHUB.TOKEN),
+      });
+    } catch(err) {
+      logAndThrow(`Invalid definition file. ${err}`);
     }
   }
 }


### PR DESCRIPTION
Fixes #372 
Fixes #373 

Issue #372 was caused because the definition file url is constructed using the PR info that we give. It will try to replace the placeholders with the PR info. So in our case it was trying to replace the BRANCH placeholder with the PR base/head branch. Since drools-jbpm does not have a 7.x branch build-chain was failing

For Issue #373 I simply wrapped the cli and github action runner in a try catch block