### PR TITLE
Run before, current and after per project

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run test:e2e
+      - run: ACT_LOG=true npm run test:e2e
+      - name: Upload raw e2e output
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-logs-${{ matrix.node-version }}.zip
+          path: '*.log'
+          retention-days: 5 
       
   package-lock-check:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.0.11",
+      "version": "3.0.12",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/src/bin/runners/cli-runner.ts
+++ b/src/bin/runners/cli-runner.ts
@@ -32,9 +32,7 @@ export class CLIRunner extends Runner {
       const postResult = await this.executePost(flowResult.isFailure);
 
       if (flowResult.isFailure || postResult.isFailure) {
-        this.printNodeExecutionFailure(flowResult.output.executionResult.before);
-        this.printNodeExecutionFailure(flowResult.output.executionResult.commands);
-        this.printNodeExecutionFailure(flowResult.output.executionResult.after);
+        this.printNodeExecutionFailure(flowResult.output.executionResult);
         this.printExecutionFailure(postResult.output);
         return process.exit(1);
       }

--- a/src/bin/runners/github-action-runner.ts
+++ b/src/bin/runners/github-action-runner.ts
@@ -43,9 +43,7 @@ export class GithubActionRunner extends Runner {
       const promise = jobSummaryService.generateSummary(flowResult.output, preResult.output, postResult.output);
 
       if (flowResult.isFailure || postResult.isFailure) {
-        this.printNodeExecutionFailure(flowResult.output.executionResult.before);
-        this.printNodeExecutionFailure(flowResult.output.executionResult.commands);
-        this.printNodeExecutionFailure(flowResult.output.executionResult.after);
+        this.printNodeExecutionFailure(flowResult.output.executionResult);
         this.printExecutionFailure(postResult.output);
         await promise;
         return process.exit(1);

--- a/src/bin/runners/runner.ts
+++ b/src/bin/runners/runner.ts
@@ -78,14 +78,16 @@ export abstract class Runner {
    * @param result
    */
   protected printNodeExecutionFailure(chainResult: ExecuteNodeResult[][]) {
-    for (const nodeResult of chainResult) {
-      for (const result of nodeResult) {
-        if (this.commandExecutionFailure(result.executeCommandResults)) {
+    chainResult.forEach(nodeResult =>
+      nodeResult
+        .filter(result =>
+          this.commandExecutionFailure(result.executeCommandResults)
+        )
+        .forEach(result => {
           this.logger.error(`Failed to execute commands for ${result.node.project}`);
           this.printExecutionFailure(result.executeCommandResults);
-        }
-      }
-    }
+        })
+    );
   }
 
   private archiveArtifactsFailure(result: PromiseSettledResult<UploadResponse>[]) {

--- a/src/domain/flow.ts
+++ b/src/domain/flow.ts
@@ -1,22 +1,15 @@
 import { UploadResponse } from "@actions/artifact";
 import { CheckedOutNode } from "@bc/domain/checkout";
 import { ExecuteNodeResult } from "@bc/domain/execute-node-result";
-import { ExecutionPhase } from "@bc/domain/execution-phase";
 
 export type FlowResult = {
   checkoutInfo: CheckedOutNode[];
   artifactUploadResults: PromiseSettledResult<UploadResponse>[];
-  executionResult: {
-    [key in ExecutionPhase]: ExecuteNodeResult[]
-  }
+  executionResult: ExecuteNodeResult[][]
 }
 
 export const defaultFlowResult: FlowResult = {
   checkoutInfo: [],
   artifactUploadResults: [],
-  executionResult: {
-    before: [],
-    after: [],
-    commands: []
-  }
+  executionResult: [[], [], []]
 }; 

--- a/src/service/job-summary/job-summary-service.ts
+++ b/src/service/job-summary/job-summary-service.ts
@@ -35,9 +35,9 @@ export class JobSummaryService {
       .addRaw("> **_Notice_**: The `GITHUB_TOKEN` should be set in the environment.", true)
       .stringify();
 
-    const before = this.constructExecutionResult(flowResult.executionResult.before, flowResult.checkoutInfo);
-    const current = this.constructExecutionResult(flowResult.executionResult.commands, flowResult.checkoutInfo);
-    const after = this.constructExecutionResult(flowResult.executionResult.after, flowResult.checkoutInfo);
+    const before = this.constructExecutionResult(flowResult.executionResult.map(res => res[0]), flowResult.checkoutInfo);
+    const current = this.constructExecutionResult(flowResult.executionResult.map(res => res[1]), flowResult.checkoutInfo);
+    const after = this.constructExecutionResult(flowResult.executionResult.map(res => res[2]), flowResult.checkoutInfo);
     const pre = this.constructPrePostResult(preResult);
     const post = this.constructPrePostResult(postResult);
 

--- a/test/e2e/branch/branch.test.ts
+++ b/test/e2e/branch/branch.test.ts
@@ -183,33 +183,35 @@ test("full downstream where 1 project has a PR and one doesn't", async () => {
       "Merged owner1/project4:branchB into branch branchB"
     )
   );
-
-  // before section
+  
+  // owner1/project1 execution
   const group5 = result[1].groups![4];
-  expect(group5.name).toBe("Executing before");
+  expect(group5.name).toBe("Executing owner1/project1");
   expect(group5.output).toEqual(
-    expect.stringContaining(" before upstream owner1/project1")
+    expect.stringContaining("before upstream owner1/project1")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default upstream")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default after current")
   );
 
-  // current section
-  const group7 = result[1].groups![6];
-  expect(group7.name).toBe("Executing commands");
-  expect(group7.output).toEqual(expect.stringContaining("default upstream"));
-  expect(group7.output).toEqual(
+  // owner1/project2 execution
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Executing owner1/project2");
+  expect(group9.output).toEqual(
     expect.stringContaining("current owner1/project2")
   );
-  expect(group7.output).toEqual(expect.stringContaining("default current"));
+  expect(group9.output).toEqual(expect.stringContaining("default after current"));
 
-  // after section
-  const group11 = result[1].groups![10];
-  expect(group11.name).toBe("Executing after");
-  expect(group11.output).toEqual(
-    expect.stringContaining("default after current")
+  // owner1/project4 execution
+  const group12 = result[1].groups![11];
+  expect(group12.name).toBe("Executing owner1/project4");
+  expect(group12.output).toEqual(
+    expect.stringContaining("default current")
   );
-  expect(group11.output).toEqual(
-    expect.stringContaining("default after current")
-  );
-  expect(group11.output).toEqual(
+  expect(group12.output).toEqual(
     expect.stringContaining("default after current")
   );
  
@@ -267,7 +269,7 @@ test("cross-pr with no PRs", async () => {
     output: "",
   });
   expect(result[1]).toMatchObject({ name: "Main ./build-chain", status: 0 });
-  expect(result[1].groups?.length).toBe(13);
+  expect(result[1].groups?.length).toBe(12);
 
   // pre section
   const group1 = result[1].groups![0];
@@ -312,35 +314,31 @@ test("cross-pr with no PRs", async () => {
     )
   );
 
-  // before section
+  // owner1/project1 section
   const group5 = result[1].groups![4];
-  expect(group5.name).toBe("Executing before");
+  expect(group5.name).toBe("Executing owner1/project1");
   expect(group5.output).toEqual(
-    expect.stringContaining(" before upstream owner1/project1")
+    expect.stringContaining("before upstream owner1/project1")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default upstream")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default after current")
   );
 
-  // current section
-  const group7 = result[1].groups![6];
-  expect(group7.name).toBe("Executing commands");
-  expect(group7.output).toEqual(expect.stringContaining("default upstream"));
-  expect(group7.output).toEqual(
+  // owner1/project2 section
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Executing owner1/project2");
+  expect(group9.output).toEqual(
     expect.stringContaining("current owner1/project2")
   );
-
-  // after section
-  const group10 = result[1].groups![9];
-  expect(group10.name).toBe("Executing after");
-  expect(group10.output).toEqual(
-    expect.stringContaining("default after current")
-  );
-  expect(group10.output).toEqual(
-    expect.stringContaining("default after current")
-  );
+  expect(group9.output).toEqual(expect.stringContaining("default after current"));
 
   // artifacts
-  const group13 = result[1].groups![12];
-  expect(group13.name).toBe("Uploading artifacts");
-  expect(group13.output).toEqual(
+  const group12 = result[1].groups![11];
+  expect(group12.name).toBe("Uploading artifacts");
+  expect(group12.output).toEqual(
     expect.stringContaining("No artifacts to archive")
   );
 

--- a/test/e2e/cross-pr/cross-pr.test.ts
+++ b/test/e2e/cross-pr/cross-pr.test.ts
@@ -206,7 +206,7 @@ test("PR from owner1/target:branchA to owner2/target:branchB while using mapping
     output: "",
   });
   expect(result[1]).toMatchObject({ name: "Main ./build-chain", status: 0 });
-  expect(result[1].groups?.length).toBe(17);
+  expect(result[1].groups?.length).toBe(18);
 
   // pre section
   const group1 = result[1].groups![0];
@@ -277,42 +277,48 @@ test("PR from owner1/target:branchA to owner2/target:branchB while using mapping
     )
   );
 
-  // before section
+  // owner1/project1 section
   const group5 = result[1].groups![4];
-  expect(group5.name).toBe("Executing before");
+  expect(group5.name).toBe("Executing owner1/project1");
   expect(group5.output).toEqual(
-    expect.stringContaining(" before upstream owner1/project1")
+    expect.stringContaining("before upstream owner1/project1")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default upstream")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default after current")
   );
 
-  // current section
-  const group7 = result[1].groups![6];
-  expect(group7.name).toBe("Executing commands");
-  expect(group7.output).toEqual(expect.stringContaining("default upstream"));
-  expect(group7.output).toEqual(
+  // owner1/project3 section
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Executing owner1/project3");
+  expect(group9.output).toEqual(expect.stringContaining("default after current"));
+
+  // owner1/project2 section
+  const group12 = result[1].groups![11];
+  expect(group12.name).toBe("Executing owner1/project2");
+  expect(group12.output).toEqual(
     expect.stringContaining("upstream owner1/project2")
   );
-  expect(group7.output).toEqual(expect.stringContaining("default current"));
+  expect(group12.output).toEqual(
+    expect.stringContaining("default after current")
+  );
 
-  // after section
-  const group12 = result[1].groups![11];
-  expect(group12.name).toBe("Executing after");
-  expect(group12.output).toEqual(
-    expect.stringContaining("default after current")
+  // owner1/project4 section
+  const group15 = result[1].groups![14];
+  expect(group15.name).toBe("Executing owner1/project4");
+  expect(group15.output).toEqual(
+    expect.stringContaining("default current")
   );
-  expect(group12.output).toEqual(
-    expect.stringContaining("default after current")
-  );
-  expect(group12.output).toEqual(
-    expect.stringContaining("default after current")
-  );
-  expect(group12.output).toEqual(
+  expect(group15.output).toEqual(
     expect.stringContaining("default after current")
   );
   
   // artifacts
-  const group17 = result[1].groups![16];
-  expect(group17.name).toBe("Uploading artifacts");
-  expect(group17.output).toEqual(
+  const group18 = result[1].groups![17];
+  expect(group18.name).toBe("Uploading artifacts");
+  expect(group18.output).toEqual(
     expect.stringContaining("No artifacts to archive")
   );
   
@@ -388,7 +394,7 @@ test("PR from target:branchA to target:branchB while using mapping of a non-star
     output: "",
   });
   expect(result[1]).toMatchObject({ name: "Main ./build-chain", status: 0 });
-  expect(result[1].groups?.length).toBe(13);
+  expect(result[1].groups?.length).toBe(12);
   
   // pre section
   const group1 = result[1].groups![0];
@@ -433,35 +439,31 @@ test("PR from target:branchA to target:branchB while using mapping of a non-star
     )
   );
   
-  // before section
+  // owner1/project1 section
   const group5 = result[1].groups![4];
-  expect(group5.name).toBe("Executing before");
+  expect(group5.name).toBe("Executing owner1/project1");
   expect(group5.output).toEqual(
-    expect.stringContaining(" before upstream owner1/project1")
+    expect.stringContaining("before upstream owner1/project1")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default upstream")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default after current")
   );
   
-  // current section
-  const group7 = result[1].groups![6];
-  expect(group7.name).toBe("Executing commands");
-  expect(group7.output).toEqual(expect.stringContaining("default upstream"));
-  expect(group7.output).toEqual(
+  // owner1/project2 section
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Executing owner1/project2");
+  expect(group9.output).toEqual(
     expect.stringContaining("current owner1/project2")
   );
-  
-  // after section
-  const group10 = result[1].groups![9];
-  expect(group10.name).toBe("Executing after");
-  expect(group10.output).toEqual(
-    expect.stringContaining("default after current")
-  );
-  expect(group10.output).toEqual(
-    expect.stringContaining("default after current")
-  );
+  expect(group9.output).toEqual(expect.stringContaining("default after current"));
   
   // artifacts
-  const group13 = result[1].groups![12];
-  expect(group13.name).toBe("Uploading artifacts");
-  expect(group13.output).toEqual(
+  const group12 = result[1].groups![11];
+  expect(group12.name).toBe("Uploading artifacts");
+  expect(group12.output).toEqual(
     expect.stringContaining("No artifacts to archive")
   );
   

--- a/test/e2e/full-downstream/full-downstream.test.ts
+++ b/test/e2e/full-downstream/full-downstream.test.ts
@@ -231,7 +231,7 @@ test("PR from owner1/target:branchA to owner2/target:branchB while using mapping
     output: "",
   });
   expect(result[1]).toMatchObject({ name: "Main ./build-chain", status: 0 });
-  expect(result[1].groups?.length).toBe(17);
+  expect(result[1].groups?.length).toBe(18);
   
   // pre section
   const group1 = result[1].groups![0];
@@ -302,42 +302,48 @@ test("PR from owner1/target:branchA to owner2/target:branchB while using mapping
     )
   );
 
-  // before section
+  // owner1/project1 section
   const group5 = result[1].groups![4];
-  expect(group5.name).toBe("Executing before");
+  expect(group5.name).toBe("Executing owner1/project1");
   expect(group5.output).toEqual(
-    expect.stringContaining(" before current owner1/project1")
+    expect.stringContaining("before current owner1/project1")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("current owner1/project1")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default after current")
   );
 
-  // current section
-  const group7 = result[1].groups![6];
-  expect(group7.name).toBe("Executing commands");
-  expect(group7.output).toEqual(expect.stringContaining("current owner1/project1"));
-  expect(group7.output).toEqual(
+  // owner1/project2 section
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Executing owner1/project2");
+  expect(group9.output).toEqual(
     expect.stringContaining("current owner1/project2")
   );
-  expect(group7.output).toEqual(expect.stringContaining("default current"));
+  expect(group9.output).toEqual(expect.stringContaining("after downstream owner1/project2"));
 
-  // after section
+  // owner1/project4 section
   const group12 = result[1].groups![11];
-  expect(group12.name).toBe("Executing after");
+  expect(group12.name).toBe("Executing owner1/project4");
   expect(group12.output).toEqual(
-    expect.stringContaining("default after current")
-  );
-  expect(group12.output).toEqual(
-    expect.stringContaining("after downstream owner1/project2")
+    expect.stringContaining("default current")
   );
   expect(group12.output).toEqual(
     expect.stringContaining("default after current")
   );
-  expect(group12.output).toEqual(
+
+  // owner1/project3 section
+  const group15 = result[1].groups![14];
+  expect(group15.name).toBe("Executing owner1/project3");
+  expect(group15.output).toEqual(
     expect.stringContaining("default after current")
   );
   
   // artifacts
-  const group17 = result[1].groups![16];
-  expect(group17.name).toBe("Uploading artifacts");
-  expect(group17.output).toEqual(
+  const group18 = result[1].groups![17];
+  expect(group18.name).toBe("Uploading artifacts");
+  expect(group18.output).toEqual(
     expect.stringContaining("No artifacts to archive")
   );
   
@@ -468,32 +474,34 @@ test("PR from target:branchA to target:branchB while using mapping of a non-star
     )
   );
 
-  // before section
+  // owner1/project1 section
   const group5 = result[1].groups![4];
-  expect(group5.name).toBe("Executing before");
+  expect(group5.name).toBe("Executing owner1/project1");
   expect(group5.output).toEqual(
-    expect.stringContaining(" before upstream owner1/project1")
+    expect.stringContaining("before upstream owner1/project1")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default upstream")
+  );
+  expect(group5.output).toEqual(
+    expect.stringContaining("default after current")
   );
 
-  // current section
-  const group7 = result[1].groups![6];
-  expect(group7.name).toBe("Executing commands");
-  expect(group7.output).toEqual(expect.stringContaining("default upstream"));
-  expect(group7.output).toEqual(
+  // owner1/project2 section
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Executing owner1/project2");
+  expect(group9.output).toEqual(
     expect.stringContaining("current owner1/project2")
   );
-  expect(group7.output).toEqual(expect.stringContaining("default current"));
+  expect(group9.output).toEqual(expect.stringContaining("default after current"));
 
-  // after section
-  const group11 = result[1].groups![10];
-  expect(group11.name).toBe("Executing after");
-  expect(group11.output).toEqual(
-    expect.stringContaining("default after current")
+  // owner1/project4 section
+  const group12 = result[1].groups![11];
+  expect(group12.name).toBe("Executing owner1/project4");
+  expect(group12.output).toEqual(
+    expect.stringContaining("default current")
   );
-  expect(group11.output).toEqual(
-    expect.stringContaining("default after current")
-  );
-  expect(group11.output).toEqual(
+  expect(group12.output).toEqual(
     expect.stringContaining("default after current")
   );
 

--- a/test/e2e/single-pr/single-pr.test.ts
+++ b/test/e2e/single-pr/single-pr.test.ts
@@ -156,7 +156,7 @@ test("PR from target:branchA to target:branchB", async () => {
     output: "",
   });
   expect(result[1]).toMatchObject({ name: "Main ./build-chain", status: 0 });
-  expect(result[1].groups?.length).toBe(10);
+  expect(result[1].groups?.length).toBe(8);
   
   // pre section
   const group1 = result[1].groups![0];
@@ -190,31 +190,20 @@ test("PR from target:branchA to target:branchB", async () => {
     )
   );
   
-  // before section
+  // owner1/project2 section
   const group5 = result[1].groups![4];
-  expect(group5.name).toBe("Executing before");
+  expect(group5.name).toBe("Executing owner1/project2");
   expect(group5.output).toEqual(
-    expect.stringContaining("No commands were found for owner1/project2")
-  );
-  
-  // current section
-  const group6 = result[1].groups![5];
-  expect(group6.name).toBe("Executing commands");
-  expect(group6.output).toEqual(
     expect.stringContaining("current owner1/project2")
   );
-  
-  // after section
-  const group8 = result[1].groups![7];
-  expect(group8.name).toBe("Executing after");
-  expect(group8.output).toEqual(
+  expect(group5.output).toEqual(
     expect.stringContaining("default after current")
   );
   
   // artifacts
-  const group10 = result[1].groups![9];
-  expect(group10.name).toBe("Uploading artifacts");
-  expect(group10.output).toEqual(
+  const group8 = result[1].groups![7];
+  expect(group8.name).toBe("Uploading artifacts");
+  expect(group8.output).toEqual(
     expect.stringContaining("No artifacts to archive")
   );
   
@@ -300,7 +289,7 @@ test("PR from owner2/target:branchA to owner1/target:branchB", async () => {
     output: "",
   });
   expect(result[1]).toMatchObject({ name: "Main ./build-chain", status: 0 });
-  expect(result[1].groups?.length).toBe(10);
+  expect(result[1].groups?.length).toBe(8);
   
   // pre section
   const group1 = result[1].groups![0];
@@ -334,31 +323,17 @@ test("PR from owner2/target:branchA to owner1/target:branchB", async () => {
     )
   );
   
-  // before section
+  // owner1/project3 section
   const group5 = result[1].groups![4];
-  expect(group5.name).toBe("Executing before");
+  expect(group5.name).toBe("Executing owner1/project3");
   expect(group5.output).toEqual(
-    expect.stringContaining("No commands were found for owner1/project3")
-  );
-  
-  // current section
-  const group6 = result[1].groups![5];
-  expect(group6.name).toBe("Executing commands");
-  expect(group6.output).toEqual(
-    expect.stringContaining("touch project3-current.log")
-  );
-  
-  // after section
-  const group8 = result[1].groups![7];
-  expect(group8.name).toBe("Executing after");
-  expect(group8.output).toEqual(
     expect.stringContaining("default after current")
   );
-  
+   
   // artifacts
-  const group10 = result[1].groups![9];
-  expect(group10.name).toBe("Uploading artifacts");
-  expect(group10.output).toEqual(
+  const group8 = result[1].groups![7];
+  expect(group8.name).toBe("Uploading artifacts");
+  expect(group8.output).toEqual(
     expect.stringContaining("Artifact owner1_project3 uploaded 1 files")
   );
   
@@ -445,7 +420,7 @@ test("PR from owner2/target:branchA to owner1/target-different-name:branchB", as
     output: "",
   });
   expect(result[1]).toMatchObject({ name: "Main ./build-chain", status: 0 });
-  expect(result[1].groups?.length).toBe(11);
+  expect(result[1].groups?.length).toBe(9);
   
   // pre section
   const group1 = result[1].groups![0];
@@ -479,31 +454,23 @@ test("PR from owner2/target:branchA to owner1/target-different-name:branchB", as
     )
   );
 
-  // before section
+  // owner1/project1 section
   const group5 = result[1].groups![4];
-  expect(group5.name).toBe("Executing before");
+  expect(group5.name).toBe("Executing owner1/project1");
   expect(group5.output).toEqual(
     expect.stringContaining("before current owner1/project1")
   );
-  
-  // current section
-  const group7 = result[1].groups![6];
-  expect(group7.name).toBe("Executing commands");
-  expect(group7.output).toEqual(
+  expect(group5.output).toEqual(
     expect.stringContaining("current owner1/project1")
   );
-  
-  // after section
-  const group9 = result[1].groups![8];
-  expect(group9.name).toBe("Executing after");
-  expect(group9.output).toEqual(
+  expect(group5.output).toEqual(
     expect.stringContaining("default after current")
   );
-  
+   
   // artifacts
-  const group11 = result[1].groups![10];
-  expect(group11.name).toBe("Uploading artifacts");
-  expect(group11.output).toEqual(
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Uploading artifacts");
+  expect(group9.output).toEqual(
     expect.stringContaining("No artifacts to archive")
   );
   

--- a/test/unitary/bin/cli-runner.test.ts
+++ b/test/unitary/bin/cli-runner.test.ts
@@ -69,7 +69,7 @@ describe("execute", () => {
   const flowOk: FlowResult = {
     artifactUploadResults: [artifactOk],
     checkoutInfo: [],
-    executionResult: { after: [nodeOk], commands: [nodeOk], before: [nodeOk] },
+    executionResult: [[nodeOk, nodeOk, nodeOk]],
   };
 
   beforeEach(() => {
@@ -123,18 +123,14 @@ describe("execute", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  test.each([
-    ["before", { after: [nodeOk], commands: [nodeOk], before: [nodeNotOk] }],
-    ["commands", { after: [nodeOk], commands: [nodeNotOk], before: [nodeOk] }],
-    ["after", { after: [nodeNotOk], commands: [nodeOk], before: [nodeOk] }],
-  ])("failure: flow - %p phase execution", async (_title, executionResult) => {
+  test("failure: flow - node execution", async () => {
     const configSpy = jest.spyOn(ConfigurationService.prototype, "init").mockImplementation(async () => undefined);
     const preSpy = jest.spyOn(PreExecutor.prototype, "run").mockImplementation(async () => [okResult]);
     const postSpy = jest.spyOn(PostExecutor.prototype, "run").mockImplementation(async () => [okResult]);
     const flowSpy = jest.spyOn(FlowService.prototype, "run").mockImplementation(async () => ({
       artifactUploadResults: [artifactOk],
       checkoutInfo: [],
-      executionResult,
+      executionResult: [[nodeOk, nodeNotOk, nodeNotOk]],
     }));
     const exitSpy = jest.spyOn(process, "exit").mockImplementation((_code?: number) => undefined as never);
 

--- a/test/unitary/bin/github-action-runner.test.ts
+++ b/test/unitary/bin/github-action-runner.test.ts
@@ -71,7 +71,7 @@ describe("execute", () => {
   const flowOk: FlowResult = {
     artifactUploadResults: [artifactOk],
     checkoutInfo: [],
-    executionResult: { after: [nodeOk], commands: [nodeOk], before: [nodeOk] },
+    executionResult: [[nodeOk, nodeOk, nodeOk]],
   };
 
   beforeEach(() => {
@@ -137,11 +137,7 @@ describe("execute", () => {
     expect(jobSummarySpy).toHaveBeenCalledWith(flowOk, [okResult], [notOkResult]);
   });
 
-  test.each([
-    ["before", { after: [nodeOk], commands: [nodeOk], before: [nodeNotOk] }],
-    ["commands", { after: [nodeOk], commands: [nodeNotOk], before: [nodeOk] }],
-    ["after", { after: [nodeNotOk], commands: [nodeOk], before: [nodeOk] }],
-  ])("failure: flow - %p phase execution", async (_title, executionResult) => {
+  test("failure: flow - %p phase execution", async () => {
     const configSpy = jest.spyOn(ConfigurationService.prototype, "init").mockImplementation(async () => undefined);
     const preSpy = jest.spyOn(PreExecutor.prototype, "run").mockImplementation(async () => [okResult]);
     const postSpy = jest.spyOn(PostExecutor.prototype, "run").mockImplementation(async () => [okResult]);
@@ -149,7 +145,7 @@ describe("execute", () => {
     const flowResult = {
       artifactUploadResults: [artifactOk],
       checkoutInfo: [],
-      executionResult,
+      executionResult: [[nodeOk, nodeNotOk, nodeNotOk]],
     };
     const flowSpy = jest.spyOn(FlowService.prototype, "run").mockImplementation(async () => flowResult);
     const exitSpy = jest.spyOn(process, "exit").mockImplementation((_code?: number) => undefined as never);

--- a/test/unitary/bin/runner.test.ts
+++ b/test/unitary/bin/runner.test.ts
@@ -34,7 +34,7 @@ class DummyRunner extends Runner {
     this.printExecutionFailure(res);
   }
 
-  testPrintNodeExecutionFailure(res: ExecuteNodeResult[]) {
+  testPrintNodeExecutionFailure(res: ExecuteNodeResult[][]) {
     this.printNodeExecutionFailure(res);
   }
 }
@@ -117,34 +117,16 @@ test.each([
     {
       artifactUploadResults: [artifactOk],
       checkoutInfo: [],
-      executionResult: { after: [nodeOk], commands: [nodeOk], before: [nodeOk] },
+      executionResult: [[nodeOk, nodeOk, nodeOk]]
     },
   ],
   [
-    "executeFlow: failure - before execution phase",
+    "executeFlow: failure",
     true,
     {
       artifactUploadResults: [artifactOk],
       checkoutInfo: [],
-      executionResult: { after: [nodeOk], commands: [nodeOk], before: [nodeNotOk] },
-    },
-  ],
-  [
-    "executeFlow: failure - commands execution phase",
-    true,
-    {
-      artifactUploadResults: [artifactOk],
-      checkoutInfo: [],
-      executionResult: { after: [nodeOk], commands: [nodeNotOk], before: [nodeOk] },
-    },
-  ],
-  [
-    "executeFlow: failure - after execution phase",
-    true,
-    {
-      artifactUploadResults: [artifactOk],
-      checkoutInfo: [],
-      executionResult: { after: [nodeNotOk], commands: [nodeOk], before: [nodeOk] },
+      executionResult: [[nodeNotOk, nodeOk, nodeOk]],
     },
   ],
   [
@@ -153,7 +135,7 @@ test.each([
     {
       artifactUploadResults: [artifactNotOk],
       checkoutInfo: [],
-      executionResult: { after: [nodeOk], commands: [nodeOk], before: [nodeOk] },
+      executionResult: [[nodeOk, nodeOk, nodeOk]],
     },
   ],
 ])("%p", async (_title: string, isFailure: boolean, output: FlowResult) => {
@@ -171,9 +153,9 @@ test.each([
 });
 
 test.each([
-  ["no failure", [nodeOk, nodeOk], 0],
-  ["failure", [nodeOk, nodeNotOk, nodeOk], 4],
-])("printNodeExecutionFailure - %p", (_title: string, result: ExecuteNodeResult[], numOfLogCalls: number) => {
+  ["no failure", [[nodeOk, nodeOk]], 0],
+  ["failure", [[nodeOk, nodeNotOk, nodeOk]], 4],
+])("printNodeExecutionFailure - %p", (_title: string, result: ExecuteNodeResult[][], numOfLogCalls: number) => {
   const loggerSpy = jest.spyOn(BaseLoggerService.prototype, "error");
   dummyRunner.testPrintNodeExecutionFailure(result);
   expect(loggerSpy).toBeCalledTimes(numOfLogCalls);

--- a/test/unitary/service/command/execute-command-service.test.ts
+++ b/test/unitary/service/command/execute-command-service.test.ts
@@ -8,7 +8,6 @@ import { defaultNodeValue } from "@bc/domain/node";
 import { NodeExecutionLevel } from "@bc/domain/node-execution";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
 import { Node } from "@kie/build-chain-configuration-reader";
-import { BaseLoggerService } from "@bc/service/logger/base-logger-service";
 import Container from "typedi";
 import { constants } from "@bc/domain/constants";
 import { EntryPoint } from "@bc/domain/entry-point";
@@ -71,123 +70,53 @@ describe("ExecuteCommandService", () => {
   });
 });
 
-describe("executeChainCommands", () => {
-
-  const nodes: Node[] = [{
-    ...defaultNodeValue,
-    project: "project1",
-    before: {
-      upstream: ["project1 before upstream 1"],
-      current: ["project1 before current 1", "project1 before current 2"],
-      downstream: ["project1 before downstream 1", "project1 before downstream 2", "project1 before downstream 3"],
-    },
-    commands: {
-      upstream: ["project1 commands upstream 1"],
-      current: ["project1 commands current 1", "project1 commands current 2"],
-      downstream: ["project1 commands downstream 1", "project1 commands downstream 2", "project1 commands downstream 3"],
-    },
-    after: {
-      upstream: ["project1 after upstream 1"],
-      current: ["project1 after current 1", "project1 after current 2"],
-      downstream: ["project1 after downstream 1", "project1 after downstream 2", "project1 after downstream 3"],
-    },
-  }, {
-    ...defaultNodeValue,
-    project: "project2",
-    before: {
-      upstream: ["project2 before upstream 1"],
-      current: ["project2 before current 1", "project2 before current 2"],
-      downstream: ["project2 before downstream 1", "project2 before downstream 2", "project2 before downstream 3"],
-    },
-    commands: {
-      upstream: ["project2 commands upstream 1"],
-      current: ["project2 commands current 1", "project2 commands current 2"],
-      downstream: ["project2 commands downstream 1", "project2 commands downstream 2", "project2 commands downstream 3"],
-    },
-    after: {
-      upstream: ["project2 after upstream 1"],
-      current: ["project2 after current 1", "project2 after current 2"],
-      downstream: ["project2 after downstream 1", "project2 after downstream 2", "project2 after downstream 3"],
-    },
-  }, {
-    ...defaultNodeValue,
-    project: "project3",
-    before: {
-      upstream: [],
-      current: ["project3 before current 1"],
-      downstream: [],
-    },
-    commands: {
-      upstream: [],
-      current: ["project3 commands current 1", "project3 commands current 2"],
-      downstream: [],
-    },
-    after: {
-      upstream: [],
-      current: ["project3 after current 1", "project3 after current 2", "project3 after current 3"],
-      downstream: [],
-    },
-  }, {
-    ...defaultNodeValue,
-    project: "project4",
-  }, {
-    ...defaultNodeValue,
-    project: "project5",
-    before: {
-      upstream: [],
-      current: [],
-      downstream: [],
-    },
-    commands: {
-      upstream: [],
-      current: [],
-      downstream: [],
-    },
-    after: {
-      upstream: [],
-      current: [],
-      downstream: [],
-    },
-  },
-  ];
-
+describe("executeNodeCommands", () => {
   test("empty nodes", async () => {
     // Arrange
-    const executionPhase: ExecutionPhase = ExecutionPhase.AFTER;
-
     const commandTreatmentDelegator = jest.mocked<CommandTreatmentDelegator>(CommandTreatmentDelegator.prototype, true);
     const commandExecutorDelegator = jest.mocked<CommandExecutorDelegator>(CommandExecutorDelegator.prototype, true);
     const configurationService = new ConfigurationService();
 
     const executeCommandService = new ExecuteCommandService(commandTreatmentDelegator, commandExecutorDelegator, configurationService);
+    jest.spyOn(executeCommandService, "getNodeCommands").mockReturnValue(undefined);
 
     // Act
-    const result = await executeCommandService.executeChainCommands([], executionPhase);
+    const result = await executeCommandService.executeNodeCommands({node: defaultNodeValue});
 
     // Arrange
-    expect(result).toStrictEqual([]);
+    expect(result).toStrictEqual([
+      {node: defaultNodeValue, executeCommandResults: []},
+      {node: defaultNodeValue, executeCommandResults: []},
+      {node: defaultNodeValue, executeCommandResults: []}
+    ]);
   });
 
   test.each([
-    [ExecutionPhase.BEFORE, NodeExecutionLevel.UPSTREAM, false, undefined, [[{ command: "project1 before upstream 1" }], [{ command: "project2 before upstream 1" }], [{ command: "project3 before current 1" }]]],
-    [ExecutionPhase.BEFORE, NodeExecutionLevel.UPSTREAM, false, "whateverThePath", [[{
-      command: "project1 before upstream 1",
-      cwd: "whateverThePath",
-    }], [{ command: "project2 before upstream 1", cwd: "whateverThePath" }], [{
-      command: "project3 before current 1",
-      cwd: "whateverThePath",
-    }]]],
-    [ExecutionPhase.BEFORE, NodeExecutionLevel.CURRENT, false, undefined, [[{ command: "project1 before current 1" }, { command: "project1 before current 2" }], [{ command: "project2 before current 1" }, { command: "project2 before current 2" }], [{ command: "project3 before current 1" }]]],
-    [ExecutionPhase.BEFORE, NodeExecutionLevel.DOWNSTREAM, false, undefined, [[{ command: "project1 before downstream 1" }, { command: "project1 before downstream 2" }, { command: "project1 before downstream 3" }], [{ command: "project2 before downstream 1" }, { command: "project2 before downstream 2" }, { command: "project2 before downstream 3" }], [{ command: "project3 before current 1" }]]],
-    [ExecutionPhase.CURRENT, NodeExecutionLevel.UPSTREAM, false, undefined, [[{ command: "project1 commands upstream 1" }], [{ command: "project2 commands upstream 1" }], [{ command: "project3 commands current 1" }, { command: "project3 commands current 2" }]]],
-    [ExecutionPhase.CURRENT, NodeExecutionLevel.CURRENT, false, undefined, [[{ command: "project1 commands current 1" }, { command: "project1 commands current 2" }], [{ command: "project1 commands current 1" }, { command: "project1 commands current 2" }], [{ command: "project3 commands current 1" }, { command: "project3 commands current 2" }]]],
-    [ExecutionPhase.CURRENT, NodeExecutionLevel.DOWNSTREAM, false, undefined, [[{ command: "project1 commands downstream 1" }, { command: "project1 commands downstream 2" }, { command: "project1 commands downstream 3" }], [{ command: "project2 commands downstream 1" }, { command: "project2 commands downstream 2" }, { command: "project2 commands downstream 3" }], [{ command: "project3 commands current 1" }, { command: "project3 commands current 2" }]]],
-    [ExecutionPhase.AFTER, NodeExecutionLevel.UPSTREAM, false, undefined, [[{ command: "project1 after upstream 1" }], [{ command: "project2 after upstream 1" }], [{ command: "project3 after current 1" }, { command: "project3 after current 2" }, { command: "project3 after current 3" }]]],
-    [ExecutionPhase.AFTER, NodeExecutionLevel.CURRENT, false, undefined, [[{ command: "project1 after current 1" }, { command: "project1 after current 2" }], [{ command: "project2 after current 1" }, { command: "project2 after current 2" }], [{ command: "project3 after current 1" }, { command: "project3 after current 2" }, { command: "project3 after current 3" }]]],
-    [ExecutionPhase.AFTER, NodeExecutionLevel.DOWNSTREAM, false, undefined, [[{ command: "project1 after downstream 1" }, { command: "project1 after downstream 2" }, { command: "project1 after downstream 3" }], [{ command: "project2 after downstream 1" }, { command: "project2 after downstream 2" }, { command: "project2 after downstream 3" }], [{ command: "project3 after current 1" }, { command: "project3 after current 2" }, { command: "project3 after current 3" }]]],
-    [ExecutionPhase.AFTER, NodeExecutionLevel.DOWNSTREAM, false, undefined, [[{ command: "project1 after downstream 1" }, { command: "project1 after downstream 2" }, { command: "project1 after downstream 3" }], [{ command: "project2 after downstream 1" }, { command: "project2 after downstream 2" }, { command: "project2 after downstream 3" }], [{ command: "project3 after current 1" }, { command: "project3 after current 2" }, { command: "project3 after current 3" }]]],
-  ])("nodes. %p %p skipExecution %p", async (executionPhase: ExecutionPhase, nodeExecutionLevel: NodeExecutionLevel, skipExecution: boolean, cwd: string | undefined, expectedCalls: ({ command: string, cwd?: string })[][]) => {
-    // Arrange
+    [NodeExecutionLevel.UPSTREAM, false, "cwd", ["upstream"], ["upstream", "", ""]],
+    [NodeExecutionLevel.DOWNSTREAM, false, "cwd", ["downstream"], ["", "", "downstream"]],
+    [NodeExecutionLevel.CURRENT, false, undefined, ["current"], ["", "current", ""]],
+    [NodeExecutionLevel.CURRENT, true, undefined, [], ["", "current", ""]],
+  ])("execute node %p skipExecution %p", async (nodeExecutionLevel: NodeExecutionLevel, skipExecution: boolean, cwd: string | undefined, expectedCalls: string[], expectedResult: string[]) => {
+    const node: Node = {
+      ...defaultNodeValue,
+      project: "project1",
+      before: {
+        upstream: ["upstream"],
+        current: [],
+        downstream: [],
+      },
+      commands: {
+        upstream: [],
+        current: ["current"],
+        downstream: [],
+      },
+      after: {
+        upstream: [],
+        current: [],
+        downstream: ["downstream"],
+      },
+    };
+  
     const commandTreatmentDelegator = jest.mocked<CommandTreatmentDelegator>(CommandTreatmentDelegator.prototype, true);
     const commandExecutorDelegator = jest.mocked<CommandExecutorDelegator>(CommandExecutorDelegator.prototype, true);
     const configurationService = jest.mocked<ConfigurationService>(ConfigurationService.prototype, true);
@@ -197,43 +126,88 @@ describe("executeChainCommands", () => {
       time: 3,
       result: ExecutionResult.OK,
       command: "commandx",
+      errorMessage: ""
     });
     (ConfigurationService.prototype.getNodeExecutionLevel as jest.Mocked<jest.Mock>).mockReturnValue(nodeExecutionLevel);
-    (ConfigurationService.prototype.getNodeExecutionLevel as jest.Mocked<jest.Mock>).mockReturnValue(nodeExecutionLevel);
     (ConfigurationService.prototype.skipExecution as jest.Mocked<jest.Mock>).mockReturnValue(skipExecution);
-
-    const expectedNumberOfCalls = skipExecution ? 0 : expectedCalls.reduce((length: number, calls: ({ command: string, cwd?: string })[]) => length + calls.length, 0);
-
     const executeCommandService = new ExecuteCommandService(commandTreatmentDelegator, commandExecutorDelegator, configurationService);
 
-    // Act
-    const result = await executeCommandService.executeChainCommands(nodes.map(node => ({node, cwd})), executionPhase);
+    jest.spyOn(executeCommandService, "getNodeCommands").mockReturnValueOnce(node["before"]![`${nodeExecutionLevel}`]);
+    jest.spyOn(executeCommandService, "getNodeCommands").mockReturnValueOnce(node["commands"]![`${nodeExecutionLevel}`]);
+    jest.spyOn(executeCommandService, "getNodeCommands").mockReturnValueOnce(node["after"]![`${nodeExecutionLevel}`]);
 
-    // Assert
-    expect(commandExecutorDelegator.executeCommand).toHaveBeenCalledTimes(expectedNumberOfCalls);
-    expect(commandTreatmentDelegator.treatCommand).toHaveBeenCalledTimes(expectedNumberOfCalls);
-    if (!skipExecution) {
-      expectedCalls.forEach(node => node.forEach(call => expect(commandTreatmentDelegator.treatCommand).toHaveBeenCalledWith(call.command, undefined)));
-      expectedCalls.forEach(node => node.forEach(call => expect(commandExecutorDelegator.executeCommand).toHaveBeenCalledWith(undefined, call.cwd)));
-    }
-    expect(BaseLoggerService.prototype.debug).toHaveBeenCalledTimes(2);
-    expect(BaseLoggerService.prototype.debug).toHaveBeenCalledWith(`No commands defined for project project4 and phase ${executionPhase}`);
-    expect(BaseLoggerService.prototype.debug).toHaveBeenCalledWith(`No commands defined for project project5 phase ${executionPhase} and level ${nodeExecutionLevel !== NodeExecutionLevel.CURRENT ? `${nodeExecutionLevel} or ${NodeExecutionLevel.CURRENT}` : NodeExecutionLevel.CURRENT}`);
+    const result = await executeCommandService.executeNodeCommands({node, cwd});
 
-    const expectedResult = nodes.map((node, index) => ({
-      node, executeCommandResults: expectedCalls[index] ? skipExecution ? expectedCalls[index].map(ec => ({
-        startingDate: expect.any(Number),
-        endingDate: expect.any(Number),
-        result: ExecutionResult.SKIP,
-        command: ec.command,
-      })) : expectedCalls[index].map(() => ({
-        startingDate: 1,
-        endingDate: 2,
-        time: 3,
-        result: ExecutionResult.OK,
-        command: "commandx",
-      })) : [],
-    }));
-    expect(result.map(r => r.executeCommandResults)).toStrictEqual(expectedResult.map(r => r.executeCommandResults));
+    expect(commandExecutorDelegator.executeCommand).toHaveBeenCalledTimes(expectedCalls.length);
+    expect(commandTreatmentDelegator.treatCommand).toHaveBeenCalledTimes(expectedCalls.length);
+    expectedCalls.forEach(call => expect(commandTreatmentDelegator.treatCommand).toHaveBeenCalledWith(call, undefined));
+    expectedCalls.forEach(_call => expect(commandExecutorDelegator.executeCommand).toHaveBeenCalledWith(undefined, cwd));
+    expect(result.map(res => res.executeCommandResults)).toStrictEqual(
+      expectedResult.map(res => (res !== "" ? [{
+        startingDate: skipExecution ? expect.any(Number) : 1,
+        endingDate: skipExecution ? expect.any(Number) : 2,
+        time: skipExecution ? 0 : 3,
+        result: skipExecution ? ExecutionResult.SKIP : ExecutionResult.OK,
+        command: skipExecution ?  res : "commandx",
+        errorMessage: ""
+      }] : []))
+    );
+  });
+});
+
+describe("getNodeCommands", () => {
+  let executeCommandService: ExecuteCommandService;
+
+  beforeEach(() => {
+    const commandTreatmentDelegator = jest.mocked<CommandTreatmentDelegator>(CommandTreatmentDelegator.prototype, true);
+    const commandExecutorDelegator = jest.mocked<CommandExecutorDelegator>(CommandExecutorDelegator.prototype, true);
+    const configurationService = jest.mocked<ConfigurationService>(ConfigurationService.prototype, true);
+    executeCommandService = new ExecuteCommandService(commandTreatmentDelegator, commandExecutorDelegator, configurationService);
+  });
+
+  test.each([
+    [
+      "execution phase defined but no commands found", 
+      {
+        current: [],
+        upstream: [],
+        downstream: []
+      },
+      NodeExecutionLevel.DOWNSTREAM,
+      []
+    ],
+    [
+      "execution phase defined but no commands for given level. use current", 
+      {
+        current: ["current"],
+        upstream: [],
+        downstream: []
+      },
+      NodeExecutionLevel.DOWNSTREAM,
+      ["current"]
+    ],
+    [
+      "execution phase defined and command for given level defined", 
+      {
+        current: [],
+        upstream: ["upstream"],
+        downstream: []
+      },
+      NodeExecutionLevel.UPSTREAM,
+      ["upstream"]
+    ],
+    [
+      "execution phase not defined", 
+      undefined,
+      NodeExecutionLevel.UPSTREAM,
+      undefined
+    ]
+  ])("%p", (_title, after, nodeExecutionLevel, expectedOutput) => {
+    const node: Node = {
+      ...defaultNodeValue,
+      after
+    };
+    const commands = executeCommandService.getNodeCommands(node, ExecutionPhase.AFTER, nodeExecutionLevel);
+    expect(commands).toStrictEqual(expectedOutput);
   });
 });

--- a/test/unitary/service/job-summary/job-summary-service.test.ts
+++ b/test/unitary/service/job-summary/job-summary-service.test.ts
@@ -4,7 +4,6 @@ import { CheckedOutNode } from "@bc/domain/checkout";
 import { constants } from "@bc/domain/constants";
 import { EntryPoint } from "@bc/domain/entry-point";
 import { ExecuteCommandResult, ExecutionResult } from "@bc/domain/execute-command-result";
-import { ExecuteNodeResult } from "@bc/domain/execute-node-result";
 import { FlowType } from "@bc/domain/inputs";
 import { defaultNodeValue } from "@bc/domain/node";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
@@ -93,47 +92,47 @@ const checkoutInfo: CheckedOutNode[] = [
   },
 ];
 
-const executionResult: ExecuteNodeResult[] = [
-  {
-    node: nodeChain[0],
-    executeCommandResults: [
-      {
-        startingDate: 0,
-        endingDate: 0,
-        time: 0,
-        command: "cmd1",
-        result: ExecutionResult.SKIP,
-        errorMessage: "error",
-      },
-    ],
-  },
-  {
-    node: nodeChain[1],
-    executeCommandResults: [
-      {
-        startingDate: 0,
-        endingDate: 2,
-        time: 2,
-        command: "cmd2",
-        result: ExecutionResult.OK,
-        errorMessage: "",
-      },
-    ],
-  },
-  {
-    node: nodeChain[2],
-    executeCommandResults: [
-      {
-        startingDate: 0,
-        endingDate: 3,
-        time: 3,
-        command: "cmd3",
-        result: ExecutionResult.NOT_OK,
-        errorMessage: "error",
-      },
-    ],
-  },
-];
+const executionResult1 = {
+  node: nodeChain[0],
+  executeCommandResults: [
+    {
+      startingDate: 0,
+      endingDate: 0,
+      time: 0,
+      command: "cmd1",
+      result: ExecutionResult.SKIP,
+      errorMessage: "error",
+    },
+  ],
+};
+
+const executionResult2 = {
+  node: nodeChain[1],
+  executeCommandResults: [
+    {
+      startingDate: 0,
+      endingDate: 2,
+      time: 2,
+      command: "cmd2",
+      result: ExecutionResult.OK,
+      errorMessage: "",
+    },
+  ],
+};
+
+const executionResult3 = {
+  node: nodeChain[2],
+  executeCommandResults: [
+    {
+      startingDate: 0,
+      endingDate: 3,
+      time: 3,
+      command: "cmd3",
+      result: ExecutionResult.NOT_OK,
+      errorMessage: "error",
+    },
+  ],
+};
 
 const artifactUploadResults: PromiseSettledResult<UploadResponse>[] = [];
 
@@ -193,7 +192,11 @@ test("non-branch flow", async () => {
     {
       checkoutInfo,
       artifactUploadResults,
-      executionResult: { before: executionResult, after: executionResult, commands: executionResult },
+      executionResult: [
+        [executionResult1, executionResult1, executionResult1], 
+        [executionResult2, executionResult2, executionResult2], 
+        [executionResult3, executionResult3, executionResult3]
+      ]
     },
     prePostResult,
     prePostResult
@@ -216,7 +219,11 @@ test("branch flow", async () => {
     {
       checkoutInfo,
       artifactUploadResults,
-      executionResult: { before: executionResult, after: executionResult, commands: executionResult },
+      executionResult: [
+        [executionResult1, executionResult1, executionResult1], 
+        [executionResult2, executionResult2, executionResult2], 
+        [executionResult3, executionResult3, executionResult3]
+      ]
     },
     prePostResult,
     prePostResult


### PR DESCRIPTION
Fixes #376 

Change was bigger than expected since executor service was not designed to be executed in such a manner.
Also updated e2e PR check to upload raw logs so that you can review it easily

