### PR TITLE
Project triggering the job

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See [action.yml](action.yml)
   - branch: executes the branch flow
   - single_pr: executes the single pull request flow
 
-- **starting-project** (optional. the project triggering the job by default): The project you want start building from. It's not the same as the project triggering the job (which will remain the same), but the project to take tree from. For instance
+- **starting-project** (optional. the project triggering the job by default): The project you want start building from. The project to construct the tree from. It's not the same as the project triggering the job which is taken from `GITHUB_REPOSITORY` env variable or the github pull request event payload. For instance
 
   > ```
   > starting-project: 'groupX/projectX' // it will get project dependencies tree from 'groupX/projectX'
@@ -494,7 +494,7 @@ Let's suppose
 
 #### mapping.dependencies
 
-It is used to define branch mapping between E and its dependencies in case `E` is `startingProject`/`projectTriggeringTheJob`.
+It is used to define branch mapping between E and its dependencies in case `E` is `projectTriggeringTheJob`.
 
 In case the `E:7.x` branch build or PR is triggered for this `7.x` target branch:
 
@@ -518,7 +518,7 @@ In case the `E:anyotherbranch` branch build or PR is triggered for this `anyothe
 
 #### mapping.dependant
 
-It is used to define branch mapping between the rest of the projects and project A in case `E` is NOT `startingProject`/`projectTriggeringTheJob`.
+It is used to define branch mapping between the rest of the projects and project A in case `E` is NOT `projectTriggeringTheJob`.
 
 In case the `A:7.x` or any other (except `main`) branch build or PR is triggered -> `E:7.x` will be taken (since there's not `mapping.dependant` for `7.x` source)
 In case the `A:main` branch build or PR is triggered -> `E:7.x` (due to `mapping.dependant.default` mapping)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.0.15",
+      "version": "3.0.16",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/src/service/checkout/checkout-service.ts
+++ b/src/service/checkout/checkout-service.ts
@@ -114,13 +114,19 @@ export class CheckoutService {
    */
   private async getCheckoutInfo(node: Node): Promise<CheckoutInfo> {
     const githubAPIService = Container.get(GithubAPIService);
-    const starterNode = this.config.getStarterNode();
+    const projectTriggeringTheJob = this.config.getProjectTriggeringTheJob();
     const originalTarget = this.config.getTargetProject();
     // the current node is the current target
     const currentTarget = {
       // map the starting project target branch to the corresponding branch defined in the mapping for the current node
       // target branch is guaranteed to exist since base always exist
-      mappedBranch: getMappedTarget(starterNode.project, starterNode.mapping, node.project, node.mapping, originalTarget.branch!),
+      mappedBranch: getMappedTarget(
+        projectTriggeringTheJob.project, 
+        projectTriggeringTheJob.mapping, 
+        node.project, 
+        node.mapping, 
+        originalTarget.branch!
+      ),
       name: node.project.split("/")[1],
       group: this.config.getGroupName() ?? node.project.split("/")[0],
     };

--- a/src/service/config/configuration-service.ts
+++ b/src/service/config/configuration-service.ts
@@ -52,7 +52,7 @@ export class ConfigurationService {
   }
 
   /**
-   * Get the name of the project starting the build-chain
+   * Get the name of the start project which produces node chain for build-chain
    * @returns {string}
    */
   getStarterProjectName(): string {
@@ -67,12 +67,31 @@ export class ConfigurationService {
   }
 
   /**
+   * Get the name of the project triggering build-chain
+   * @returns {string}
+    */
+  getProjectTriggeringTheJobName(): string {
+    return process.env.GITHUB_REPOSITORY ??
+      this.configuration.gitEventData.base.repo.full_name ??
+      this.configuration.parsedInputs.startProject;
+  }
+
+  /**
    * Check whether the given node is the starter project
    * @param node
    * @returns {Boolean} true if the node is the starter project
    */
   isNodeStarter(node: Node): boolean {
     return node.project === this.getStarterProjectName();
+  }
+
+  /**
+   * Check whether the given node is the triggering node
+   * @param node
+   * @returns {Boolean} true if the node is the triggering node
+   */
+  isNodeTriggeringTheJob(node: Node): boolean {
+      return node.project === this.getProjectTriggeringTheJobName();
   }
 
   /**
@@ -87,6 +106,14 @@ export class ConfigurationService {
             Please choose a different project like starter or define the project ${this.getStarterProjectName()} in the tree.`);
     }
     return starterNode;
+  }
+
+  /**
+   * Finds the node triggering the job
+   * @returns {Node} starter node
+   */
+  getProjectTriggeringTheJob(): Node {
+    return this.nodeChain.find(node => this.isNodeTriggeringTheJob(node)) ?? this.getStarterNode();
   }
 
   /**

--- a/test/unitary/service/checkout/checkout-service.test.ts
+++ b/test/unitary/service/checkout/checkout-service.test.ts
@@ -73,7 +73,7 @@ describe.each([
     jest.spyOn(ConfigurationService.prototype, "getRootFolder").mockImplementation(() => rootFolder);
     jest.spyOn(ConfigurationService.prototype, "getSourceProject").mockImplementation(() => originalSource);
     jest.spyOn(ConfigurationService.prototype, "getTargetProject").mockImplementation(() => originalTarget);
-    jest.spyOn(ConfigurationService.prototype, "getStarterNode").mockImplementation(() => nodeChain[1]);
+    jest.spyOn(ConfigurationService.prototype, "getProjectTriggeringTheJob").mockImplementation(() => nodeChain[1]);
     jest.spyOn(ConfigurationService.prototype, "skipParallelCheckout").mockImplementation(() => skipParallelCheckout);
   });
 
@@ -291,7 +291,7 @@ describe.each([
     jest.spyOn(ConfigurationService.prototype, "getRootFolder").mockImplementation(() => rootFolder);
     jest.spyOn(ConfigurationService.prototype, "getSourceProject").mockImplementation(() => originalSource);
     jest.spyOn(ConfigurationService.prototype, "getTargetProject").mockImplementation(() => originalTarget);
-    jest.spyOn(ConfigurationService.prototype, "getStarterNode").mockImplementation(() => nodeChain[1]);
+    jest.spyOn(ConfigurationService.prototype, "getProjectTriggeringTheJob").mockImplementation(() => nodeChain[1]);
     jest.spyOn(ConfigurationService.prototype, "skipParallelCheckout").mockImplementation(() => skipParallelCheckout);
   });
 
@@ -507,7 +507,7 @@ describe.each([
     jest.spyOn(ConfigurationService.prototype, "getRootFolder").mockImplementation(() => rootFolder);
     jest.spyOn(ConfigurationService.prototype, "getSourceProject").mockImplementation(() => originalSource);
     jest.spyOn(ConfigurationService.prototype, "getTargetProject").mockImplementation(() => originalTarget);
-    jest.spyOn(ConfigurationService.prototype, "getStarterNode").mockImplementation(() => nodeChain[1]);
+    jest.spyOn(ConfigurationService.prototype, "getProjectTriggeringTheJob").mockImplementation(() => nodeChain[1]);
     jest.spyOn(ConfigurationService.prototype, "skipParallelCheckout").mockImplementation(() => skipParallelCheckout);
   });
 

--- a/test/unitary/service/config/configuration-service.test.ts
+++ b/test/unitary/service/config/configuration-service.test.ts
@@ -47,6 +47,7 @@ describe("methods", () => {
   let config: ConfigurationService;
   let currentInput: InputValues;
   const startProject = "owner/project";
+  const projectTriggeringTheJob = "owner/job";
 
   beforeAll(() => {
     // doesn't matter whether it is a CLI or action
@@ -376,5 +377,39 @@ describe("methods", () => {
       group
     };
     expect(config.getGroupName()).toBe(group);
+  });
+
+  test.each([
+    ["github env is defined", projectTriggeringTheJob, undefined, projectTriggeringTheJob],
+    ["github event is defined", undefined, projectTriggeringTheJob, projectTriggeringTheJob],
+    ["neither is defined use startProject", undefined, undefined, startProject],
+  ])("getProjectTriggeringTheJobName: %p", (_title, githubEnv, githubEvent, expected) => {
+    if (githubEnv) {
+      process.env["GITHUB_REPOSITORY"] = githubEnv;
+    }
+    jest
+      .spyOn(BaseConfiguration.prototype, "gitEventData", "get")
+      .mockImplementationOnce(() => ({ base: {repo: {full_name: githubEvent}} }) as never);
+    expect(config.getProjectTriggeringTheJobName()).toBe(expected);
+    delete process.env["GITHUB_REPOSITORY"];
+  });
+
+  test.each([
+    ["projectTriggeringTheJob is found", projectTriggeringTheJob, projectTriggeringTheJob],
+    ["projectTriggeringTheJob is not found", undefined, startProject],
+  ])("getProjectTriggeringTheJob: %p", (_title, getProjectTriggeringTheJobName, expectedProject) => {
+    const chain: Node[] = [
+      { ...defaultNodeValue, project: "abc" },
+      { ...defaultNodeValue, project: startProject },
+      { ...defaultNodeValue, project: projectTriggeringTheJob },
+    ];
+    const nodeFound: Node = { ...defaultNodeValue, project: expectedProject };
+    jest
+      .spyOn(ConfigurationService.prototype, "nodeChain", "get")
+      .mockImplementation(() => chain);
+    jest
+      .spyOn(ConfigurationService.prototype, "getProjectTriggeringTheJobName")
+      .mockImplementation(() => getProjectTriggeringTheJobName!);
+    expect(config.getProjectTriggeringTheJob()).toStrictEqual(nodeFound);
   });
 });


### PR DESCRIPTION
Make a distinction between project triggering the job and starting project.

Example command:
```
build-chain build cross_pr --token **** -f https://raw.githubusercontent.com/kiegroup/optaplanner/main/.ci/buildchain-config.yaml -o bc -p kiegroup/optaplanner-quickstarts -u https://github.com/kiegroup/optaplanner/pull/2580 --skipParallelCheckout
```
Over here we need `optaplanner-quickstarts` to be the starting project and use that to produce the node-chain and we need `optaplanner` to be the project triggering the job and use `optaplanner` to produce the mapping