### PR TITLE
fix request-error dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@actions/exec": "^1.1.1",
         "@actions/glob": "^0.3.0",
         "@kie/build-chain-configuration-reader": "^3.0.10",
-        "@octokit/request-error": "^3.0.3",
+        "@octokit/request-error": "^2.1.0",
         "@octokit/rest": "^18.12.0",
         "@octokit/types": "^6.39.0",
         "commander": "^9.3.0",
@@ -1476,6 +1476,35 @@
         "node": ">= 14"
       }
     },
+    "node_modules/@octokit/core/node_modules/@octokit/request-error": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "peer": true,
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==",
+      "peer": true
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^16.0.0"
+      }
+    },
     "node_modules/@octokit/core/node_modules/@octokit/types": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
@@ -1557,32 +1586,6 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
-      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
-    },
-    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
-      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
-      "dependencies": {
-        "@octokit/openapi-types": "^16.0.0"
-      }
-    },
-    "node_modules/@octokit/request/node_modules/@octokit/request-error": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
       "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
@@ -1627,16 +1630,6 @@
       },
       "peerDependencies": {
         "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/request-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
-      "dependencies": {
-        "@octokit/types": "^6.0.3",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
       }
     },
     "node_modules/@octokit/types": {
@@ -8744,6 +8737,34 @@
             "universal-user-agent": "^6.0.0"
           }
         },
+        "@octokit/request-error": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+          "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+          "peer": true,
+          "requires": {
+            "@octokit/types": "^9.0.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          },
+          "dependencies": {
+            "@octokit/openapi-types": {
+              "version": "16.0.0",
+              "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+              "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==",
+              "peer": true
+            },
+            "@octokit/types": {
+              "version": "9.0.0",
+              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+              "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+              "peer": true,
+              "requires": {
+                "@octokit/openapi-types": "^16.0.0"
+              }
+            }
+          }
+        },
         "@octokit/types": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
@@ -8821,43 +8842,16 @@
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/request-error": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-          "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
-          "requires": {
-            "@octokit/types": "^6.0.3",
-            "deprecation": "^2.0.0",
-            "once": "^1.4.0"
-          }
-        }
       }
     },
     "@octokit/request-error": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
       "requires": {
-        "@octokit/types": "^9.0.0",
+        "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      },
-      "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "16.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
-          "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
-        },
-        "@octokit/types": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
-          "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
-          "requires": {
-            "@octokit/openapi-types": "^16.0.0"
-          }
-        }
       }
     },
     "@octokit/rest": {
@@ -8892,16 +8886,6 @@
           "requires": {
             "@octokit/types": "^6.39.0",
             "deprecation": "^2.3.1"
-          }
-        },
-        "@octokit/request-error": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-          "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
-          "requires": {
-            "@octokit/types": "^6.0.3",
-            "deprecation": "^2.0.0",
-            "once": "^1.4.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.0.16",
+      "version": "3.0.17",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@actions/core": "^1.8.2",
     "@actions/exec": "^1.1.1",
     "@actions/glob": "^0.3.0",
-    "@octokit/request-error": "^3.0.3",
+    "@octokit/request-error": "^2.1.0",
     "@kie/build-chain-configuration-reader": "^3.0.10",
     "@octokit/rest": "^18.12.0",
     "@octokit/types": "^6.39.0",

--- a/src/service/git/github-api.ts
+++ b/src/service/git/github-api.ts
@@ -128,10 +128,10 @@ export class GithubAPIService {
     if (err instanceof RequestError) {
       switch (err.status) {
         case 401:
-          reason = "Failed to authenticate with provided token, please use -token argument to provide a new one. You can also check your GITHUB_TOKEN environment variable and check whether the provided token is still valid.";
+          reason = "Failed to authenticate with provided token, please use --token argument to provide a new one. You can also check your GITHUB_TOKEN environment variable and check whether the provided token is still valid.";
           break;
         case 404:
-          reason = "Failed to fetch GitHub URL, please check if the URL used in -url argument is valid and if the token you are using have permissions to access it.";
+          reason = "Failed to fetch GitHub resource, please check if resource you requested does exits, the URL used in -u argument is valid, and if the token you are using have permissions to access it.";
           break;
         case 403:
           reason = "Failed to fetch resource. Either your github token does not have access to the requested resource or you have reached your github api rate limit.";


### PR DESCRIPTION
Due to a misalignment of versions in `@octokit/rest` and `@octokit/request-error` the error thrown by octokit/rest wasn't recognized as an instance of `RequestError`. This caused us not to produce the right error message.

`@octokit/rest@^18.12.0` requires `@octokit/request-error^2.1.0` . This was a bit difficult catch since `@octokit/request-error` is not a direct dependency of `@octokit/rest` and for some reason when installing `@octokit/rest` it automatically installed `@octokit/request-error^3.0.3` (even when it was not a dependency in our package.json)