### PR TITLE
Refactor load git event for cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.0.17",
+      "version": "3.0.18",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/src/service/git/github-api.ts
+++ b/src/service/git/github-api.ts
@@ -123,6 +123,32 @@ export class GithubAPIService {
     }
   }
 
+  /**
+   * Returns the pull request info of a given repo and pr number
+   * @param owner the owner of the repo
+   * @param repo the name of the repo
+   * @param pullNumber the pr number
+   * @returns pull request info
+   */
+  async getPullRequest(owner: string, repo: string, pullNumber: number) {
+    try {
+      const { data } = await this.octokit.pulls.get({
+          owner,
+          repo,
+          pull_number: pullNumber,
+      });
+      return data;
+    } catch(err) {
+      this.logger.error(
+        this.getErrorMessage(
+          err,
+          `Failed to fetch pull ${pullNumber} for ${owner}/${repo}.`
+        )
+      );
+      throw err;
+    }
+  }
+
   private getErrorMessage(err: unknown, msg: string): string {
     let reason;
     if (err instanceof RequestError) {

--- a/src/service/git/github-api.ts
+++ b/src/service/git/github-api.ts
@@ -132,6 +132,7 @@ export class GithubAPIService {
    */
   async getPullRequest(owner: string, repo: string, pullNumber: number) {
     try {
+      this.logger.debug(`Making a github API call to get pull request info for ${owner}/${repo} PR #${pullNumber}`);
       const { data } = await this.octokit.pulls.get({
           owner,
           repo,

--- a/test/unitary/service/git/github-api.test.ts
+++ b/test/unitary/service/git/github-api.test.ts
@@ -167,3 +167,28 @@ test.each([
     }
   }
 );
+
+test.each([
+  ["success", 200],
+  ["failure", 404],
+])("getPullRequest %p", async (_title: string, status: number) => {
+  const moctokit = new Moctokit();
+  moctokit.rest.pulls.get({
+    owner: "owner",
+    repo: "repo",
+    pull_number: 128
+  }).reply({
+    status: status as 200 | 404,
+    data: {title: "some_pr"}
+  });
+
+  if (status == 200) {
+    await expect(git.getPullRequest("owner", "repo", 128)).resolves.toStrictEqual(
+      {
+        title: "some_pr"
+      }
+    );
+  } else {
+    await expect(git.getPullRequest("owner", "repo", 128)).rejects.toThrowError();
+  }
+});


### PR DESCRIPTION
Create a github api method for the octokit call we are making directly inside cli-configuration service. This way all github api calls will use the same error handler.

Fixes the vague error from here - https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/kogito/job/main/job/pullrequest/job/kogito-runtimes.tests.kogito-runtimes/1980/display/redirect
