### PR TITLE
Improve get forked name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.22",
+  "version": "3.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.0.22",
+      "version": "3.0.23",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.22",
+  "version": "3.0.23",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/src/service/git/github-api.ts
+++ b/src/service/git/github-api.ts
@@ -159,7 +159,7 @@ export class GithubAPIService {
     }
   }
 
-  private async checkIfRepositoryExists(owner: string, repo: string) {
+  private async checkIfRepositoryExists(owner: string, repo: string): Promise<string | undefined> {
     try {
       this.logger.debug(`Making a github API call to check whether ${owner}/${repo} exists`);
       await this.octokit.repos.get({

--- a/test/e2e/cross-pr/cross-pr.test.ts
+++ b/test/e2e/cross-pr/cross-pr.test.ts
@@ -157,6 +157,16 @@ test("PR from owner1/target:branchA to owner2/target:branchB while using mapping
       bind: true,
       mockApi: [
         moctokit.rest.repos
+          .get({
+            owner: "owner1",
+            repo: /project(1|2|4)/,
+          })
+          .setResponse({
+            status: 404,
+            data: {},
+            repeat: 3
+          }),
+        moctokit.rest.repos
           .listForks({
             owner: "owner1",
             repo: "project4",
@@ -173,13 +183,13 @@ test("PR from owner1/target:branchA to owner2/target:branchB while using mapping
             ],
           }),
         moctokit.rest.repos
-          .listForks({
+          .get({
             owner: "owner1",
             repo: "project3",
           })
           .setResponse({
             status: 200,
-            data: [{ name: "project3", owner: { login: "owner2" } }],
+            data: { name: "project3", owner: { login: "owner1" } },
           }),
         moctokit.rest.repos
           .listForks({

--- a/test/e2e/full-downstream/full-downstream.test.ts
+++ b/test/e2e/full-downstream/full-downstream.test.ts
@@ -186,6 +186,16 @@ test("PR from owner1/target:branchA to owner2/target:branchB while using mapping
       bind: true,
       mockApi: [
         moctokit.rest.repos
+          .get({
+            owner: "owner1",
+            repo: /project(1|2|3|4)/,
+          })
+          .setResponse({
+            status: 404,
+            data: {},
+            repeat: 4
+          }),
+        moctokit.rest.repos
           .listForks({
             owner: "owner1",
             repo: "project1",

--- a/test/e2e/single-pr/single-pr.test.ts
+++ b/test/e2e/single-pr/single-pr.test.ts
@@ -261,20 +261,18 @@ test("PR from owner2/target:branchA to owner1/target:branchB", async () => {
       },
       mockApi: [
         moctokit.rest.repos
-          .listForks({
+          .get({
             owner: "owner1",
             repo: "project3",
           })
           .setResponse({
             status: 200,
-            data: [
-              {
-                name: "project3",
-                owner: {
-                  login: "owner2",
-                },
+            data: {
+              name: "project3",
+              owner: {
+                login: "owner1",
               },
-            ],
+            },
           }),
         moctokit.rest.pulls
           .list()
@@ -391,6 +389,15 @@ test("PR from owner2/target:branchA to owner1/target-different-name:branchB", as
       workflowFile: repoPath,
       bind: true,
       mockApi: [
+        moctokit.rest.repos
+          .get({
+            owner: "owner1",
+            repo: "project1",
+          })
+          .setResponse({
+            status: 404,
+            data: {},
+          }),
         moctokit.rest.repos
           .listForks({
             owner: "owner1",


### PR DESCRIPTION
Part of #410 

To get a fork name we are using the list forks API which is paginated. So we end up going through each page until we find the fork. This would result in 24 API calls in case like these - https://github.com/kiegroup/drools/pull/5116

Now we are using the list forks API since there are cases where the forked repository name might be different than the original repository. However after investigating the forks of some our major repositories, it seems like most of the forked repositories have the same name as the original repository. The ones with different name are generally way less (although they do exist). These are the repositories I checked but I think the general trend is the same in the other repositories:

- https://github.com/kiegroup/drools/network/members
- https://github.com/kiegroup/optaplanner/network/members
- https://github.com/kiegroup/kogito-runtimes/network/members

This PR aims to take advantage of this fact and reduce the number of API calls. The idea is that we will directly check whether a forked repository with same name exists or not. If it exists then we are done and we don't have to loop through all the forks. 

Taking the same example, for this PR https://github.com/kiegroup/drools/pull/5116 we would make about 24 API calls to get the fork name, but now with this change we will only make 1.

So we will be able to reduce the number of API calls for the majority of the cases. For the rest we still have to investigate :)
