### PR TITLE
Update publish-action.yml

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -11,6 +11,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build:action
       - uses: JasonEtco/build-and-tag-action@v2


### PR DESCRIPTION
The default node version in github action runners is now node 18 - https://github.com/actions/runner-images/discussions/5429
Until we thoroughly test node 18 effects on build-chain we have to stick with node 16