### PR TITLE
upgrade build-chain-config-reader to 3.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/core": "^1.8.2",
         "@actions/exec": "^1.1.1",
         "@actions/glob": "^0.3.0",
-        "@kie/build-chain-configuration-reader": "^3.0.11",
+        "@kie/build-chain-configuration-reader": "^3.0.13",
         "@octokit/plugin-throttling": "^5.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/rest": "^18.12.0",
@@ -1317,9 +1317,9 @@
       "dev": true
     },
     "node_modules/@kie/build-chain-configuration-reader": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.11.tgz",
-      "integrity": "sha512-65K2O1XSxLvPROlgBIpGG0EZ/IcyXABODR05H2vb3NdA08VYcDGJdkvEEyIeTPQMcNprNdDwa4gplo/e4Abt0w==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.13.tgz",
+      "integrity": "sha512-QHUo8crKkJ4xinFuj6QQUXstnHi9ofpjqIVxPn/Ik5/z2adcKsIWdwp/iHUvKlMlCA6XPfYhelt2Fkh8HWpvtA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "axios": "^0.27.2",
@@ -8645,9 +8645,9 @@
       }
     },
     "@kie/build-chain-configuration-reader": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.11.tgz",
-      "integrity": "sha512-65K2O1XSxLvPROlgBIpGG0EZ/IcyXABODR05H2vb3NdA08VYcDGJdkvEEyIeTPQMcNprNdDwa4gplo/e4Abt0w==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.13.tgz",
+      "integrity": "sha512-QHUo8crKkJ4xinFuj6QQUXstnHi9ofpjqIVxPn/Ik5/z2adcKsIWdwp/iHUvKlMlCA6XPfYhelt2Fkh8HWpvtA==",
       "requires": {
         "ajv": "^8.11.0",
         "axios": "^0.27.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.0.23",
+      "version": "3.0.24",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",
@@ -51,105 +51,6 @@
       },
       "engines": {
         "node": ">= 14.19.3"
-      }
-    },
-    "../act-js": {
-      "name": "@kie/act-js",
-      "version": "2.0.4",
-      "extraneous": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@kie/mock-github": "^1.0.1",
-        "ajv": "^8.12.0",
-        "express": "^4.18.1",
-        "follow-redirects": "^1.15.2",
-        "yaml": "^2.1.3"
-      },
-      "bin": {
-        "act-js": "build/bin/act"
-      },
-      "devDependencies": {
-        "@octokit/rest": "^19.0.5",
-        "@types/express": "^4.17.13",
-        "@types/follow-redirects": "^1.14.1",
-        "@types/jest": "^28.1.3",
-        "@types/node": "^18.0.0",
-        "@typescript-eslint/eslint-plugin": "^5.48.2",
-        "@typescript-eslint/parser": "^5.48.2",
-        "axios": "^1.1.3",
-        "eslint": "^8.32.0",
-        "jest": "^28.1.1",
-        "jest-sonar-reporter": "^2.0.0",
-        "nock": "^13.3.0",
-        "prettier": "^2.7.1",
-        "ts-jest": "^28.0.5",
-        "ts-node": "^10.8.1",
-        "tsc-alias": "^1.7.1",
-        "typescript": "^4.7.4"
-      }
-    },
-    "../build-chain-configuration-reader": {
-      "name": "@kie/build-chain-configuration-reader",
-      "version": "3.0.8",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^8.11.0",
-        "axios": "^0.27.2",
-        "yaml": "^2.1.1"
-      },
-      "devDependencies": {
-        "@types/jest": "^28.1.1",
-        "@types/node": "^17.0.41",
-        "@typescript-eslint/eslint-plugin": "^5.27.1",
-        "@typescript-eslint/parser": "^5.27.1",
-        "eslint": "^8.17.0",
-        "husky": "^8.0.1",
-        "jest": "^28.1.1",
-        "jest-sonar-reporter": "^2.0.0",
-        "nock": "^13.2.9",
-        "ts-jest": "^28.0.4",
-        "ts-node": "^10.8.1",
-        "tsc-alias": "^1.7.1",
-        "typescript": "^4.7.3"
-      }
-    },
-    "../mock-github": {
-      "name": "@kie/mock-github",
-      "version": "1.0.3",
-      "extraneous": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@octokit/openapi-types-ghec": "^14.0.0",
-        "ajv": "^8.11.0",
-        "express": "^4.18.1",
-        "fast-glob": "^3.2.12",
-        "fs-extra": "^10.1.0",
-        "nock": "^13.2.7",
-        "simple-git": "^3.8.0",
-        "totalist": "^3.0.0"
-      },
-      "devDependencies": {
-        "@actions/artifact": "^1.1.0",
-        "@octokit/rest": "^19.0.4",
-        "@types/express": "^4.17.13",
-        "@types/fs-extra": "^9.0.13",
-        "@types/jest": "^28.1.3",
-        "@types/node": "^18.0.0",
-        "@typescript-eslint/eslint-plugin": "^5.48.2",
-        "@typescript-eslint/parser": "^5.48.2",
-        "@vercel/ncc": "^0.34.0",
-        "axios": "^0.27.2",
-        "eslint": "^8.32.0",
-        "github-openapi-graphql-query": "^2.1.2",
-        "jest": "^28.1.1",
-        "jest-sonar-reporter": "^2.0.0",
-        "npm-run-all": "^4.1.5",
-        "prettier": "^2.7.1",
-        "ts-jest": "^28.0.5",
-        "ts-node": "^10.8.1",
-        "tsc-alias": "^1.7.1",
-        "typescript": "^4.7.4"
       }
     },
     "node_modules/@actions/artifact": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@actions/core": "^1.8.2",
     "@actions/exec": "^1.1.1",
     "@actions/glob": "^0.3.0",
-    "@kie/build-chain-configuration-reader": "^3.0.11",
+    "@kie/build-chain-configuration-reader": "^3.0.13",
     "@octokit/plugin-throttling": "^5.0.1",
     "@octokit/request-error": "^2.1.0",
     "@octokit/rest": "^18.12.0",

--- a/src/service/config/definition-file-reader.ts
+++ b/src/service/config/definition-file-reader.ts
@@ -6,12 +6,12 @@ import { LoggerService } from "@bc/service/logger/logger-service";
 import { logAndThrow } from "@bc/utils/log";
 import {
   DefinitionFile,
-  getOrderedListForProject,
   getTreeForProject,
-  parentChainFromNode,
   readDefinitionFile,
   Node,
   ReaderOpts,
+  getFullDownstreamProjects,
+  getUpstreamProjects
 } from "@kie/build-chain-configuration-reader";
 import Container from "typedi";
 
@@ -32,38 +32,30 @@ export class DefinitionFileReader {
     switch (this.configuration.getFlowType()) {
       case FlowType.BRANCH: {
         if (this.configuration.parsedInputs.fullProjectDependencyTree) {
-          nodeChain = await getOrderedListForProject(
+          nodeChain = await getFullDownstreamProjects(
             this.configuration.parsedInputs.definitionFile,
             starterProject,
             options
           );
         } else {
-          const node = await getTreeForProject(
+          nodeChain = await getUpstreamProjects(
             this.configuration.parsedInputs.definitionFile,
             starterProject,
             options
           );
-          if (!node) {
-            throw new Error("Starting project not found");
-          }
-          nodeChain = parentChainFromNode(node);
         }
         break;
       }
       case FlowType.CROSS_PULL_REQUEST: {
-        const node = await getTreeForProject(
+        nodeChain = await getUpstreamProjects(
           this.configuration.parsedInputs.definitionFile,
           starterProject,
           options
         );
-        if (!node) {
-          throw new Error("Starting project not found");
-        }
-        nodeChain = parentChainFromNode(node);
         break;
       }
       case FlowType.FULL_DOWNSTREAM: {
-        nodeChain = await getOrderedListForProject(
+        nodeChain = await getFullDownstreamProjects(
           this.configuration.parsedInputs.definitionFile,
           starterProject,
           options

--- a/test/e2e/branch/branch.test.ts
+++ b/test/e2e/branch/branch.test.ts
@@ -214,20 +214,20 @@ test("full downstream where 1 project has a PR and one doesn't", async () => {
     expect.stringContaining("default after current")
   );
 
-  // owner1/project3 execution
-  const group9 = result[1].groups![8];
-  expect(group9.name).toBe("Executing owner1/project3");
-  expect(group9.output).toEqual(
-    expect.stringContaining("default after current")
-  );
-
   // owner1/project2 execution
-  const group12 = result[1].groups![11];
-  expect(group12.name).toBe("Executing owner1/project2");
-  expect(group12.output).toEqual(
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Executing owner1/project2");
+  expect(group9.output).toEqual(
     expect.stringContaining("current owner1/project2")
   );
-  expect(group12.output).toEqual(expect.stringContaining("default after current"));
+  expect(group9.output).toEqual(expect.stringContaining("default after current"));
+
+  // owner1/project3 execution
+  const group12 = result[1].groups![11];
+  expect(group12.name).toBe("Executing owner1/project3");
+  expect(group12.output).toEqual(
+    expect.stringContaining("default after current")
+  );
 
   // owner1/project4 execution
   const group15 = result[1].groups![14];

--- a/test/e2e/full-downstream/full-downstream.test.ts
+++ b/test/e2e/full-downstream/full-downstream.test.ts
@@ -330,20 +330,20 @@ test("PR from owner1/target:branchA to owner2/target:branchB while using mapping
     expect.stringContaining("default after current")
   );
 
-  // owner1/project3 section
-  const group9 = result[1].groups![8];
-  expect(group9.name).toBe("Executing owner1/project3");
-  expect(group9.output).toEqual(
-    expect.stringContaining("default after current")
-  );
-
   // owner1/project2 section
-  const group12 = result[1].groups![11];
-  expect(group12.name).toBe("Executing owner1/project2");
-  expect(group12.output).toEqual(
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Executing owner1/project2");
+  expect(group9.output).toEqual(
     expect.stringContaining("current owner1/project2")
   );
-  expect(group12.output).toEqual(expect.stringContaining("after downstream owner1/project2"));
+  expect(group9.output).toEqual(expect.stringContaining("after downstream owner1/project2"));
+
+  // owner1/project3 section
+  const group12 = result[1].groups![11];
+  expect(group12.name).toBe("Executing owner1/project3");
+  expect(group12.output).toEqual(
+    expect.stringContaining("default after current")
+  );
 
   // owner1/project4 section
   const group15 = result[1].groups![14];
@@ -515,18 +515,17 @@ test("PR from target:branchA to target:branchB while using mapping of a non-star
     expect.stringContaining("default after current")
   );
 
-  // owner1/project3 section
-  const group9 = result[1].groups![8];
-  expect(group9.name).toBe("Executing owner1/project3");
-  expect(group9.output).toEqual(expect.stringContaining("default after current"));
-
-
   // owner1/project2 section
-  const group12 = result[1].groups![11];
-  expect(group12.name).toBe("Executing owner1/project2");
-  expect(group12.output).toEqual(
+  const group9 = result[1].groups![8];
+  expect(group9.name).toBe("Executing owner1/project2");
+  expect(group9.output).toEqual(
     expect.stringContaining("current owner1/project2")
   );
+  expect(group9.output).toEqual(expect.stringContaining("default after current"));
+
+  // owner1/project3 section
+  const group12 = result[1].groups![11];
+  expect(group12.name).toBe("Executing owner1/project3");
   expect(group12.output).toEqual(expect.stringContaining("default after current"));
 
   // owner1/project4 section

--- a/test/unitary/service/config/definition-file-reader.test.ts
+++ b/test/unitary/service/config/definition-file-reader.test.ts
@@ -4,7 +4,7 @@ import { constants } from "@bc/domain/constants";
 import { EntryPoint } from "@bc/domain/entry-point";
 import { defaultInputValues, FlowType } from "@bc/domain/inputs";
 import { BaseConfiguration } from "@bc/service/config/base-configuration";
-import { getOrderedListForProject, getTreeForProject, parentChainFromNode, readDefinitionFile, Node } from "@kie/build-chain-configuration-reader";
+import { getTreeForProject, readDefinitionFile, Node, getFullDownstreamProjects, getUpstreamProjects } from "@kie/build-chain-configuration-reader";
 import fs from "fs";
 import path from "path";
 import Container from "typedi";
@@ -55,28 +55,28 @@ describe.each([
   });
 
   test("success: from source generated placeholder", async () => {
-    const getOrderedListProjectMock = getOrderedListForProject as jest.Mock;
-    getOrderedListProjectMock.mockReturnValueOnce(mockData);
+    const getFullDownstreamProjectsMock = getFullDownstreamProjects as jest.Mock;
+    getFullDownstreamProjectsMock.mockReturnValueOnce(mockData);
 
     await definitionFileReader.generateNodeChain(mockData[0].project);
-    expect(getOrderedListProjectMock).toHaveBeenCalledTimes(1);
+    expect(getFullDownstreamProjectsMock).toHaveBeenCalledTimes(1);
   });
 
   test("success: from target generated placeholder", async () => {
-    const getOrderedListProjectMock = getOrderedListForProject as jest.Mock;
-    getOrderedListProjectMock
+    const getFullDownstreamProjectsMock = getFullDownstreamProjects as jest.Mock;
+    getFullDownstreamProjectsMock
       .mockImplementationOnce(() => {
         throw new Error("Invalid definition file");
       })
       .mockReturnValueOnce(mockData);
 
     await definitionFileReader.generateNodeChain(mockData[0].project);
-    expect(getOrderedListProjectMock).toHaveBeenCalledTimes(2);
+    expect(getFullDownstreamProjectsMock).toHaveBeenCalledTimes(2);
   });
 
   test("failure", async () => {
-    const getOrderedListProjectMock = getOrderedListForProject as jest.Mock;
-    getOrderedListProjectMock.mockImplementation(() => {
+    const getFullDownstreamProjectsMock = getFullDownstreamProjects as jest.Mock;
+    getFullDownstreamProjectsMock.mockImplementation(() => {
       throw new Error("Invalid definition file");
     });
     await expect(definitionFileReader.generateNodeChain("test")).rejects.toThrowError();
@@ -96,32 +96,26 @@ describe.each([
   });
 
   test("success: from source generated placeholder", async () => {
-    const getTreeForProjectMock = getTreeForProject as jest.Mock;
-    const parentChainFromNodeMock = parentChainFromNode as jest.Mock;
-    getTreeForProjectMock.mockReturnValueOnce({project: "abc"});
-    parentChainFromNodeMock.mockReturnValueOnce(mockData);
+    const getUpstreamProjectsMock = getUpstreamProjects as jest.Mock;
+    getUpstreamProjectsMock.mockReturnValueOnce(mockData);
 
     await definitionFileReader.generateNodeChain(mockData[0].project);
-    expect(parentChainFromNodeMock).toHaveBeenCalledTimes(1);
-    expect(getTreeForProjectMock).toHaveBeenCalledTimes(1);
+    expect(getUpstreamProjectsMock).toHaveBeenCalledTimes(1);
   });
 
   test("success: from target generated placeholder", async () => {
-    const getTreeForProjectMock = getTreeForProject as jest.Mock;
-    const parentChainFromNodeMock = parentChainFromNode as jest.Mock;
-    getTreeForProjectMock.mockImplementationOnce(() => {
+    const getUpstreamProjectsMock = getUpstreamProjects as jest.Mock;
+    getUpstreamProjectsMock.mockImplementationOnce(() => {
       throw new Error("Invalid definition file");
-    }).mockReturnValueOnce({project: "abc"});
-    parentChainFromNodeMock.mockReturnValueOnce(mockData);
+    }).mockReturnValueOnce(mockData);
 
     await definitionFileReader.generateNodeChain(mockData[0].project);
-    expect(parentChainFromNodeMock).toHaveBeenCalledTimes(1);
-    expect(getTreeForProjectMock).toHaveBeenCalledTimes(2);
+    expect(getUpstreamProjectsMock).toHaveBeenCalledTimes(2);
   });
 
   test("failure", async () => {
-    const getTreeForProjectMock = getTreeForProject as jest.Mock;
-    getTreeForProjectMock.mockImplementation(() => {
+    const getUpstreamProjectsMock = getUpstreamProjects as jest.Mock;
+    getUpstreamProjectsMock.mockImplementation(() => {
       throw new Error("Invalid definition file");
     });
     await expect(definitionFileReader.generateNodeChain("test")).rejects.toThrowError();


### PR DESCRIPTION
fixes #408 

Upgraded build-chain-config-reader to enable `skip` mechanism and to start using graph functions