### PR TITLE
add workflow that will update build-chain-config-reader

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,31 @@
+name: Update build-chain-configuration-reader
+
+on:
+  repository_dispatch:
+    types: [update-build-chain-configuration-reader]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version of https://www.npmjs.com/package/@kie/build-chain-configuration-reader
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm i @kie/build-chain-configuration-reader@${{ github.event.client_payload.version }}
+      - run: npm version patch --no-git-tag-version
+      - name: Create Pull Request
+        uses: gr2m/create-or-update-pull-request-action@v1.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: Update build-chain-configuration-reader to ${{ github.event.client_payload.version }}
+          body: >
+            There is a new release of build-chain-configuration-reader. Verify that there are no breaking changes
+          branch: build-chain-configuration-reader-${{ github.event.client_payload.version }}
+          commit-message: build-chain-configuration-reader updated


### PR DESCRIPTION
fixes #424 

When this repository receives an event called `update-build-chain-configuration-reader` it will trigger this new workflow which will update build-chain-configuration-reader with the new version, bump up patch version and create a PR 