### PR TITLE
add reviewers for PRs opened by github-bot

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,3 +29,4 @@ jobs:
             There is a new release of build-chain-configuration-reader. Verify that there are no breaking changes
           branch: build-chain-configuration-reader-${{ github.event.client_payload.version }}
           commit-message: build-chain-configuration-reader updated
+          team_reviewers: kiegroup/productization


### PR DESCRIPTION
Since all build-chain-configuration updates are automated and the github-bot opens PR to update them, we should also add reviewers to the opened PRs to notify them. I choose to add the productization team and not a specific user