### PR TITLE
Enable parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ See [action.yml](action.yml)
   > annotations-prefix: "OS ${{ matrix.os }}"
   > ```
 
+- **enable-parallel-execution** (optional. false by default): By enabling parallel execution, build-chain will try to detect projects that can be executed parallely without any conflicts i.e. no 2 projects where 1 depends on another will be executed parallely.
+
 - **additional-flags** (optional. '' by default): The chance to define additional flags for the execution, as it is done on the CLI side. Just semicolon (;) separated, like '--skipParallelCheckout;--skipExecution;-t (mvn .\*)||\$1 -s settings.xml'.
 
   > ```
@@ -606,6 +608,7 @@ Options:
                                          false)
   --skipProjectExecution <projects...>   A flag to skip execution and artifacts archiving for certain projects only
   --skipParallelCheckout                 Checkout the project sequentially (default: false)
+  --enableParallelExecution              Parallely execute projects (default: false)
   -t, --customCommandTreatment <exp...>  Each exp must be of the form <RegEx||ReplacementEx>. Regex defines the regular expression for what you want
                                          to replace with the ReplacementEx
   --skipProjectCheckout <projects...>    A list of projects to skip checkout.
@@ -641,6 +644,7 @@ Options:
                                          false)
   --skipProjectExecution <projects...>   A flag to skip execution and artifacts archiving for certain projects only
   --skipParallelCheckout                 Checkout the project sequentially (default: false)
+  --enableParallelExecution              Parallely execute projects (default: false)
   -t, --customCommandTreatment <exp...>  Each exp must be of the form <RegEx||ReplacementEx>. Regex defines the regular expression for what you want
                                          to replace with the ReplacementEx
   --skipProjectCheckout <projects...>    A list of projects to skip checkout.
@@ -676,6 +680,7 @@ Options:
                                          false)
   --skipProjectExecution <projects...>   A flag to skip execution and artifacts archiving for certain projects only
   --skipParallelCheckout                 Checkout the project sequentially (default: false)
+  --enableParallelExecution              Parallely execute projects (default: false)
   -t, --customCommandTreatment <exp...>  Each exp must be of the form <RegEx||ReplacementEx>. Regex defines the regular expression for what you want
                                          to replace with the ReplacementEx
   --skipProjectCheckout <projects...>    A list of projects to skip checkout.
@@ -715,6 +720,7 @@ Options:
                                          false)
   --skipProjectExecution <projects...>   A flag to skip execution and artifacts archiving for certain projects only
   --skipParallelCheckout                 Checkout the project sequentially (default: false)
+  --enableParallelExecution              Parallely execute projects (default: false)
   -t, --customCommandTreatment <exp...>  Each exp must be of the form <RegEx||ReplacementEx>. Regex defines the regular expression for what you want
                                          to replace with the ReplacementEx
   --skipProjectCheckout <projects...>    A list of projects to skip checkout.

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: "Checkout the project sequentially or parallely"
     default: "false"
     required: false
+  enable-parallel-execution:
+    description: "Parallely execute projects"
+    default: "false"
+    required: false
   custom-command-treatment:
     description: "<RegEx||ReplacementEx> Regex defines the regular expression for what you want to replace with the ReplacementEx"
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.27",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.0.27",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/core": "^1.8.2",
         "@actions/exec": "^1.1.1",
         "@actions/glob": "^0.3.0",
-        "@kie/build-chain-configuration-reader": "^3.0.15",
+        "@kie/build-chain-configuration-reader": "^3.0.16",
         "@octokit/plugin-throttling": "^5.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/rest": "^18.12.0",
@@ -1218,9 +1218,9 @@
       "dev": true
     },
     "node_modules/@kie/build-chain-configuration-reader": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.15.tgz",
-      "integrity": "sha512-55vKaTSzfSPTbY3lXIhKzJwEIgQcwWFVgNAJ0MksW7yke7CiUrySP8g1vy5YUi0Yda9CbwDNn3x+Fz/1N5D5pQ==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.16.tgz",
+      "integrity": "sha512-rC1RZKckjB/Sw9TsZBQZnXAKLra/zf5I56W0uOVaqNg/CNTYoA9BpIqkrL7cH8Toc0yA7yJiqY/cqWeUuvwwTA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "axios": "^0.27.2",
@@ -8546,9 +8546,9 @@
       }
     },
     "@kie/build-chain-configuration-reader": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.15.tgz",
-      "integrity": "sha512-55vKaTSzfSPTbY3lXIhKzJwEIgQcwWFVgNAJ0MksW7yke7CiUrySP8g1vy5YUi0Yda9CbwDNn3x+Fz/1N5D5pQ==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.16.tgz",
+      "integrity": "sha512-rC1RZKckjB/Sw9TsZBQZnXAKLra/zf5I56W0uOVaqNg/CNTYoA9BpIqkrL7cH8Toc0yA7yJiqY/cqWeUuvwwTA==",
       "requires": {
         "ajv": "^8.11.0",
         "axios": "^0.27.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@kie/mock-github": "^1.0.3",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^28.1.1",
-        "@types/node": "^17.0.41",
+        "@types/node": "^18.16.3",
         "@typescript-eslint/eslint-plugin": "^5.27.1",
         "@typescript-eslint/parser": "^5.27.1",
         "@vercel/ncc": "^0.34.0",
@@ -45,7 +45,7 @@
         "nock": "^13.2.7",
         "npm-run-all": "^4.1.5",
         "ts-jest": "^28.0.4",
-        "ts-node": "^10.8.1",
+        "ts-node": "^10.9.1",
         "tsc-alias": "^1.8.2",
         "typescript": "^4.7.3"
       },
@@ -1770,9 +1770,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
-      "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ==",
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -7157,9 +7157,9 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -9060,9 +9060,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
-      "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ==",
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
       "dev": true
     },
     "@types/prettier": {
@@ -13018,9 +13018,9 @@
       }
     },
     "ts-node": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.0.27",
+  "version": "3.1.0",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@kie/mock-github": "^1.0.3",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^28.1.1",
-    "@types/node": "^17.0.41",
+    "@types/node": "^18.16.3",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
     "@vercel/ncc": "^0.34.0",
@@ -53,7 +53,7 @@
     "nock": "^13.2.7",
     "npm-run-all": "^4.1.5",
     "ts-jest": "^28.0.4",
-    "ts-node": "^10.8.1",
+    "ts-node": "^10.9.1",
     "tsc-alias": "^1.8.2",
     "typescript": "^4.7.3"
   },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@actions/core": "^1.8.2",
     "@actions/exec": "^1.1.1",
     "@actions/glob": "^0.3.0",
-    "@kie/build-chain-configuration-reader": "^3.0.15",
+    "@kie/build-chain-configuration-reader": "^3.0.16",
     "@octokit/plugin-throttling": "^5.0.1",
     "@octokit/request-error": "^2.1.0",
     "@octokit/rest": "^18.12.0",

--- a/src/bin/runners/cli-runner.ts
+++ b/src/bin/runners/cli-runner.ts
@@ -25,16 +25,16 @@ export class CLIRunner extends Runner {
         return await this.executeBuild(); 
       }      
     } catch (err) {
-      process.exit(1);
+      await this.safeAsyncExit(1);
     }
   }
 
-  private async executeBuild() {
+  private async executeBuild(): Promise<void> {
     // execute pre section
     const preResult = await this.executePre();
     if (preResult.isFailure) {
       this.printExecutionFailure(preResult.output);
-      return process.exit(1);
+      return this.safeAsyncExit(1);
     }
 
     // execute flow: checkout node chain -> execute commands for each phase -> upload artifacts
@@ -43,11 +43,13 @@ export class CLIRunner extends Runner {
     // execute post section
     const postResult = await this.executePost(flowResult.isFailure);
 
+    let exitCode = 0;
     if (flowResult.isFailure || postResult.isFailure) {
       this.printNodeExecutionFailure(flowResult.output.executionResult);
       this.printExecutionFailure(postResult.output);
-      return process.exit(1);
+      exitCode = 1;
     }
+    return this.safeAsyncExit(exitCode);
   }
 
   private async executeTools() {

--- a/src/bin/runners/github-action-runner.ts
+++ b/src/bin/runners/github-action-runner.ts
@@ -29,7 +29,7 @@ export class GithubActionRunner extends Runner {
         const promise = jobSummaryService.generateSummary(defaultFlowResult, preResult.output, []);
         this.printExecutionFailure(preResult.output);
         await promise;
-        return process.exit(1);
+        return await this.safeAsyncExit(1);
       }
 
       // execute flow: checkout node chain -> execute commands for each phase -> upload artifacts
@@ -41,17 +41,17 @@ export class GithubActionRunner extends Runner {
       // post a job summary
       // io task is involved so start it as a promise and wait for it when actually needed
       const promise = jobSummaryService.generateSummary(flowResult.output, preResult.output, postResult.output);
-
+      let exitCode = 0;
       if (flowResult.isFailure || postResult.isFailure) {
         this.printNodeExecutionFailure(flowResult.output.executionResult);
         this.printExecutionFailure(postResult.output);
-        await promise;
-        return process.exit(1);
+        exitCode = 1;
       }
-
       await promise;
+      
+      return await this.safeAsyncExit(exitCode);
     } catch (err) {
-      process.exit(1);
+      await this.safeAsyncExit(1);
     }
   }
 }

--- a/src/bin/runners/runner.ts
+++ b/src/bin/runners/runner.ts
@@ -91,6 +91,18 @@ export abstract class Runner {
     );
   }
 
+  protected async safeAsyncExit(exitCode: number): Promise<void> {
+    if (process.stdout.writableNeedDrain) {
+      // wait for stdout to flush
+      await new Promise<void>((resolve, _reject) => {
+        process.stdout.once("drain", () => {
+          resolve();
+        });
+      });
+    }   
+    return process.exit(exitCode);   
+  }
+
   private archiveArtifactsFailure(result: PromiseSettledResult<UploadResponse>[]) {
     return !!result.find(res => res.status === "rejected");
   }

--- a/src/domain/inputs.ts
+++ b/src/domain/inputs.ts
@@ -27,6 +27,7 @@ export interface InputValues extends OptionValues {
   flowType?: FlowType;
   CLICommand?: CLIActionType;
   CLISubCommand?: FlowType | ToolType;
+  enableParallelExecution: boolean;
   skipExecution: boolean;
   skipParallelCheckout: boolean;
   skipCheckout: boolean;
@@ -50,5 +51,6 @@ export const defaultInputValues: Readonly<InputValues> = {
   skipExecution: false,
   skipCheckout: false,
   skipParallelCheckout: false,
+  enableParallelExecution: false,
   loggerLevel: LoggerLevel.INFO,
 };

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -3,5 +3,6 @@ import { Node } from "@kie/build-chain-configuration-reader";
 export const defaultNodeValue: Readonly<Node> = {
   project: "",
   parents: [],
-  children: []
+  children: [],
+  depth: -1
 };

--- a/src/service/arguments/action/action-arguments.ts
+++ b/src/service/arguments/action/action-arguments.ts
@@ -104,6 +104,7 @@ export class ActionArguments {
       skipParallelCheckout: core.getBooleanInput("skip-parallel-checkout"),
       skipProjectCheckout: this.getArrayInput("skip-project-checkout"),
       skipProjectExecution: this.getArrayInput("skip-project-execution"),
+      enableParallelExecution: core.getBooleanInput("enable-parallel-execution"),
       skipCheckout: core.getBooleanInput("skip-checkout"),
       startProject: this.getStringInput("starting-project"),
       loggerLevel: this.getLoggerLevel(core.getInput("logger-level")),

--- a/src/service/arguments/cli/build/build-subcommand-factory.ts
+++ b/src/service/arguments/cli/build/build-subcommand-factory.ts
@@ -47,6 +47,7 @@ export class BuildSubCommandFactory {
       .option("--skipExecution", "A flag to skip execution and artifacts archiving for all projects. Overrides skipProjectExecution", false)
       .option("--skipProjectExecution <projects...>", "A flag to skip execution and artifacts archiving for certain projects only")
       .option("--skipParallelCheckout", "Checkout the project sequentially", false)
+      .option("--enableParallelExecution", "Parallely execute projects", false)
       .option("-t, --customCommandTreatment <exp...>", "Each exp must be of the form <RegEx||ReplacementEx>. Regex defines the regular expression for what you want to replace with the ReplacementEx")
       .option("--skipProjectCheckout <projects...>", "A list of projects to skip checkout.")
       .option("--skipCheckout", "skip checkout for all projects. Overrides skipProjectCheckout", false)

--- a/src/service/command/execute-command-service.ts
+++ b/src/service/command/execute-command-service.ts
@@ -8,30 +8,41 @@ import { ExecutionPhase } from "@bc/domain/execution-phase";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
 import { NodeExecution, NodeExecutionLevel } from "@bc/domain/node-execution";
 import { Node } from "@kie/build-chain-configuration-reader";
+import { BaseLoggerService } from "@bc/service/logger/base-logger-service";
+import { ExecOptions } from "@actions/exec";
 
 @Service()
 export class ExecuteCommandService {
+  private logger: BaseLoggerService;
 
   constructor(private _commandTreatmentDelegator: CommandTreatmentDelegator,
               private _commandExecutorDelegator: CommandExecutorDelegator,
-              private _configurationService: ConfigurationService) {
+              private _configurationService: ConfigurationService,
+            ) {
+    this.logger = Container.get(LoggerService).logger;
   }
 
-  public async executeCommand(command: string, cwd?: string): Promise<ExecuteCommandResult> {
+  public async executeNodeChain(chain: NodeExecution[], printResults?: (node: ExecuteNodeResult[]) => void) {
+    return this._configurationService.isParallelExecutionEnabled() ?
+            this.executeNodeChainParallel(chain, printResults) :
+            this.executeNodeChainSequential(chain, printResults);
+  }
+
+  public async executeCommand(command: string, opts?: ExecOptions): Promise<ExecuteCommandResult> {
     const treatedCommand = this._commandTreatmentDelegator.treatCommand(command, this._configurationService.getTreatmentOptions());
-    return this._commandExecutorDelegator.executeCommand(treatedCommand, cwd);
+    return this._commandExecutorDelegator.executeCommand(treatedCommand, opts);
   }
 
-  public async executeNodeCommands(nodeToBeExecuted: NodeExecution): Promise<ExecuteNodeResult[]> {
+  public async executeNodeCommands(nodeToBeExecuted: NodeExecution, opts?: ExecOptions): Promise<ExecuteNodeResult[]> {
     const result: ExecuteNodeResult[] = [];
     const {node, cwd} = nodeToBeExecuted;
     const before = this.getNodeCommands(node, ExecutionPhase.BEFORE, this._configurationService.getNodeExecutionLevel(node));
     const current = this.getNodeCommands(node, ExecutionPhase.CURRENT, this._configurationService.getNodeExecutionLevel(node));
     const after = this.getNodeCommands(node, ExecutionPhase.AFTER, this._configurationService.getNodeExecutionLevel(node));
     const skipExecution = this._configurationService.skipExecution(node);
-    result.push(await this.executeCommands(node, before ?? [], skipExecution, cwd));
-    result.push(await this.executeCommands(node, current ?? [], skipExecution, cwd));
-    result.push(await this.executeCommands(node, after ?? [], skipExecution, cwd));
+    result.push(await this.executeCommands(node, before ?? [], skipExecution, {...opts, cwd}));
+    result.push(await this.executeCommands(node, current ?? [], skipExecution, {...opts, cwd}));
+    result.push(await this.executeCommands(node, after ?? [], skipExecution, {...opts, cwd}));
     return result;
   }
 
@@ -42,15 +53,15 @@ export class ExecuteCommandService {
       levelCommands = commands[`${nodeExecutionLevel}`].length ? commands[`${nodeExecutionLevel}`] : commands[`${NodeExecutionLevel.CURRENT}`];
     }
     if (!commands) {
-      Container.get(LoggerService).logger.debug(`No commands defined for project ${node.project} and phase ${executionPhase}`);
+      this.logger.debug(`No commands defined for project ${node.project} and phase ${executionPhase}`);
     } else if (!levelCommands || !levelCommands.length) {
       const levelMsg = nodeExecutionLevel !== NodeExecutionLevel.CURRENT ? `${nodeExecutionLevel} or ${NodeExecutionLevel.CURRENT}` : NodeExecutionLevel.CURRENT;
-      Container.get(LoggerService).logger.debug(`No commands defined for project ${node.project} phase ${executionPhase} and level ${levelMsg}`);
+      this.logger.debug(`No commands defined for project ${node.project} phase ${executionPhase} and level ${levelMsg}`);
     }
     return levelCommands;
   }
 
-  private async executeCommands(node: Node, commands: string[], skipExecution: boolean, cwd?: string): Promise<ExecuteNodeResult> {
+  private async executeCommands(node: Node, commands: string[], skipExecution: boolean, opts?: ExecOptions): Promise<ExecuteNodeResult> {
     const result: ExecuteNodeResult = {
       node,
       executeCommandResults: [],
@@ -64,9 +75,91 @@ export class ExecuteCommandService {
           result: ExecutionResult.SKIP,
           errorMessage: "",
           time: 0
-        } : await this.executeCommand(command, cwd));
+        } : await this.executeCommand(command, opts));
     }
     return result;
   }
 
+  private async executeNodeChainSequential(chain: NodeExecution[], printResults?: (node: ExecuteNodeResult[]) => void) {
+    const result: ExecuteNodeResult[][] = [];
+    for (const node of chain) {
+      this.logger.startGroup(`Executing ${node.node.project}`);
+      const currentNodeResult = await this.executeNodeCommands(node);
+      result.push(currentNodeResult);
+      this.logger.info(`Execution summary for ${node.node.project}`);
+      
+      if (printResults) {
+        printResults(currentNodeResult);
+      }
+      
+      this.logger.endGroup();
+    }
+    return result;
+  }
+
+  private async executeNodeChainParallel(chain: NodeExecution[], printResults?: (node: ExecuteNodeResult[]) => void) {
+    const result: ExecuteNodeResult[][] = [];
+    const maxDepth = Math.max(...chain.map(c => c.node.depth));
+
+    // we can only execute projects that have the same depth since these projects don't depend each other
+    this.logger.startGroup("Calculating projects that can be executed parallely");
+    const groups = chain.reduce((prev: Record<number, NodeExecution[]>, curr) => {
+      if (!prev[curr.node.depth]) {
+        prev[curr.node.depth] = [];
+      }
+      prev[curr.node.depth].push(curr);
+      return prev;
+    }, {});
+
+    Object.entries(groups).forEach(v => {
+      this.logger.info(`${parseInt(v[0]) + 1}. [${v[1].map(n => n.node.project)}]`);
+    });
+    this.logger.endGroup();
+
+    for (let depth = 0; depth <= maxDepth; depth += 1) {
+      // start executing the current group and storing their output in buffer. Don't await right now just start execution
+      const buffers = groups[depth].reduce((prev: Record<string, Buffer>, curr) => {
+        prev[curr.node.project] = Buffer.alloc(0);
+        return prev;
+      }, {});
+      const currentResults: Record<string, ExecuteNodeResult[]> = {};
+      await Promise.all(
+        groups[depth].map(
+          node => this.executeNodeCommands(node, {
+              silent: true, 
+              listeners: {
+                stdout: data => {
+                  buffers[node.node.project] = Buffer.concat([
+                    buffers[node.node.project],
+                    data
+                  ]);
+                },
+                stderr: data => {
+                  buffers[node.node.project] = Buffer.concat([
+                    buffers[node.node.project],
+                    data
+                  ]);
+                }
+              }
+            })
+            .then(r => {
+              currentResults[node.node.project] = r;
+              result.push(r);
+            })
+        )
+      );
+      
+      // print output to stdout for the previous group
+      for (const [project, buffer] of Object.entries(buffers)) {
+        this.logger.startGroup(`Executing ${project}`);
+        this.logger.logger.log(buffer.toString());
+        this.logger.info(`Execution summary for ${project}`);
+        if (printResults) {
+          printResults(currentResults[project]);
+        }
+        this.logger.endGroup();
+      }
+    }
+    return result;
+  }
 }

--- a/src/service/command/executor/bash-executor.ts
+++ b/src/service/command/executor/bash-executor.ts
@@ -1,10 +1,10 @@
-import { exec } from "@actions/exec";
+import { exec, ExecOptions } from "@actions/exec";
 import { Service } from "typedi";
 
 @Service()
 export class BashExecutor {
 
-  async execute(command: string, cwd?: string): Promise<void> {
-    await exec(command, [], { cwd });
+  async execute(command: string, opts?: ExecOptions): Promise<void> {
+    await exec(command, [], opts);
   }
 }

--- a/src/service/command/executor/command-executor-delegator.ts
+++ b/src/service/command/executor/command-executor-delegator.ts
@@ -1,9 +1,9 @@
-import Container, { Service } from "typedi";
+import { Service } from "typedi";
 import { BashExecutor } from "@bc/service/command/executor/bash-executor";
 import { ExportExecutor } from "@bc/service/command/executor/export-executor";
 import { ExecuteCommandResult, ExecutionResult } from "@bc/domain/execute-command-result";
-import { LoggerService } from "@bc/service/logger/logger-service";
 import { hrtimeToMs } from "@bc/utils/date";
+import { ExecOptions } from "@actions/exec";
 
 @Service()
 export class CommandExecutorDelegator {
@@ -12,18 +12,17 @@ export class CommandExecutorDelegator {
               private _exportExecutor: ExportExecutor) {
   }
 
-  public async executeCommand(command: string, cwd?: string): Promise<ExecuteCommandResult> {
+  public async executeCommand(command: string, opts?: ExecOptions): Promise<ExecuteCommandResult> {
     const startHrTime = process.hrtime();
     const startingDate = Date.now();
     let result: ExecutionResult;
     let errorMessage = "";
     
     try {
-      this.isExport(command) ? await this._exportExecutor.execute(command, cwd) : await this._bashExecutor.execute(command, cwd);
+      this.isExport(command) ? await this._exportExecutor.execute(command, opts) : await this._bashExecutor.execute(command, opts);
       result = ExecutionResult.OK;
     } catch (ex) {
       errorMessage = (ex instanceof Error) ? ex.message : "unknown";
-      Container.get(LoggerService).logger.error(`Error executing command ${command}. ${errorMessage}`);
       result = ExecutionResult.NOT_OK;
     }
     return {

--- a/src/service/config/configuration-service.ts
+++ b/src/service/config/configuration-service.ts
@@ -167,6 +167,15 @@ export class ConfigurationService {
   }
 
   /**
+   * Checks whether projects should be executed sequential or parallel
+   * @returns {Boolean} true if project execution should be parallel otherwise false
+   */
+  isParallelExecutionEnabled(): boolean {
+    return this.configuration.parsedInputs.enableParallelExecution;
+  }
+  
+
+  /**
    * Parses user input from custom command treatment option to create the treatment option object
    * @returns {TreatmentOptions} Construct the treatment options domain object
    */

--- a/src/service/flow/flow-service.ts
+++ b/src/service/flow/flow-service.ts
@@ -178,19 +178,6 @@ export class FlowService {
     }
   }
 
-  private async executeAndPrint(chain: NodeExecution[]): Promise<ExecuteNodeResult[][]> {
-    const result: ExecuteNodeResult[][] = [];
-    for (const node of chain) {
-      this.logger.startGroup(`Executing ${node.node.project}`);
-      const currentNodeResult = await this.executor.executeNodeCommands(node);
-      result.push(currentNodeResult);
-      this.logger.info(`Execution summary for ${node.node.project}`);
-      this.printExecutionSummary(currentNodeResult);
-      this.logger.endGroup();
-    }
-    return result;
-  }
-
   private isNodeExecutionSkipped(result: ExecuteNodeResult) {
     return !!result.executeCommandResults.find(res => res.result === ExecutionResult.SKIP);
   }

--- a/src/service/flow/flow-service.ts
+++ b/src/service/flow/flow-service.ts
@@ -52,8 +52,7 @@ export class FlowService {
       cwd: checkoutInfo.find(info => info.node.project === node.project)!.checkoutInfo?.repoDir,
     }));
 
-    const executionResult = await this.executeAndPrint(nodeChainForExecution);
-
+    const executionResult = await this.executor.executeNodeChain(nodeChainForExecution, this.printExecutionSummary.bind(this));
     // archive artifacts
     this.logger.startGroup("Uploading artifacts");
     const artifactUploadResults = await this.artifactService.uploadNodes(this.configService.nodeChain, this.configService.getStarterNode());

--- a/src/service/pre-post/pre-post.ts
+++ b/src/service/pre-post/pre-post.ts
@@ -20,10 +20,10 @@ export abstract class PrePostExecutor {
     const result: ExecuteCommandResult[] = [];
     if (Array.isArray(cmds)) {
       for (const cmd of cmds) {
-        result.push(await this.executeService.executeCommand(cmd, process.cwd()));
+        result.push(await this.executeService.executeCommand(cmd, {cwd: process.cwd()}));
       }
     } else {
-      result.push(await this.executeService.executeCommand(cmds, process.cwd()));
+      result.push(await this.executeService.executeCommand(cmds, {cwd: process.cwd()}));
     }
     return result;
   }

--- a/test/e2e/parallel/parallel-execution.test.ts
+++ b/test/e2e/parallel/parallel-execution.test.ts
@@ -1,0 +1,164 @@
+import { GitActionTypes, MockGithub, Moctokit } from "@kie/mock-github";
+import path from "path";
+import { Act } from "@kie/act-js";
+import { logActOutput } from "../helper/logger";
+
+let mockGithub: MockGithub;
+beforeEach(async () => {
+  mockGithub = new MockGithub(
+    {
+      repo: {
+        "build-chain": {
+          files: [
+            {
+              src: path.resolve(__dirname, "..", "resources"),
+              dest: ".github/",
+            },
+            {
+              src: path.join(__dirname, "parallel-execution.yaml"),
+              dest: ".github/workflows/parallel-execution.yaml",
+            },
+            {
+              src: path.resolve(__dirname, "..", "..", "..", "action.yml"),
+              dest: "action.yml",
+            },
+            {
+              src: path.resolve(__dirname, "..", "..", "..", "dist-e2e"),
+              dest: "dist",
+            },
+          ],
+        },
+        "owner1/project1": {
+          pushedBranches: ["branchA", "8.B"],
+          history: [
+            {
+              action: GitActionTypes.PUSH,
+              branch: "branchA",
+            },
+            {
+              action: GitActionTypes.PUSH,
+              branch: "8.B",
+            }
+          ],
+        },
+        "owner1/project2": {
+          pushedBranches: ["branchA", "branchB"],
+          history: [
+            {
+              action: GitActionTypes.PUSH,
+              branch: "branchA",
+            },
+            {
+              action: GitActionTypes.PUSH,
+              branch: "branchB",
+            }
+          ],
+        },
+        "owner1/project3": {
+          pushedBranches: ["branchB", "branchA"],
+          history: [
+            {
+              action: GitActionTypes.PUSH,
+              branch: "branchB",
+            },
+            {
+              action: GitActionTypes.PUSH,
+              branch: "branchA",
+            },
+          ],
+        },
+        "owner1/project4": {
+          pushedBranches: ["branchB", "branchA"],
+          history: [
+            {
+              action: GitActionTypes.PUSH,
+              branch: "branchB",
+            },
+            {
+              action: GitActionTypes.PUSH,
+              branch: "branchA",
+            }
+          ],
+        },
+      },
+    },
+    path.join(__dirname, "setup")
+  );
+  await mockGithub.setup();
+});
+
+afterEach(async () => {
+  await mockGithub.teardown();
+});
+
+test("PR from target:branchA to target:branchB while using mapping of a non-starting project (mapping.dependant.X)", async () => {
+  const moctokit = new Moctokit("http://api.github.com");
+  const act = new Act();
+  const repoPath = mockGithub.repo.getPath("build-chain");
+  const parentDir = path.dirname(repoPath!);
+  const result = await act
+    .setGithubToken("token")
+    .setEnv("GITHUB_SERVER_URL", `${parentDir}${path.sep}`)
+    .setEnv("GITHUB_REPOSITORY", "owner1/project2")
+    .setEvent({
+      pull_request: {
+        head: {
+          ref: "branchA",
+          repo: {
+            full_name: "owner1/project2",
+            name: "project2",
+            owner: {
+              login: "owner1",
+            },
+          },
+        },
+        base: {
+          ref: "branchB",
+          repo: {
+            full_name: "owner1/project2",
+            name: "project2",
+            owner: {
+              login: "owner1",
+            },
+          },
+        },
+      },
+    })
+    .runEvent("pull_request", {
+      ...logActOutput("parallel-execution.log"),
+      cwd: parentDir,
+      workflowFile: repoPath,
+      bind: true,
+      mockApi: [
+        moctokit.rest.repos
+          .get({
+            owner: "owner1",
+            repo: /project(1|2|3|4)/,
+          })
+          .setResponse({ status: 200, data: {}, repeat: 4 }),
+        moctokit.rest.pulls
+          .list({
+            owner: "owner1",
+            repo: /project(1|2|3|4)/,
+          })
+          .setResponse({ status: 200, data: [{ title: "pr" }], repeat: 4 }),
+      ],
+    });
+  expect(result.length).toBe(3);
+  expect(result[1]).toMatchObject({ name: "Main ./build-chain", status: 0 });
+  
+  // parallel execution calculations
+  const parallelExecutionGroup = result[1].groups![4];
+  expect(parallelExecutionGroup.name).toBe("Calculating projects that can be executed parallely");
+  expect(parallelExecutionGroup.output).toEqual(expect.stringContaining("1. [owner1/project1]"));
+  expect(parallelExecutionGroup.output).toEqual(expect.stringContaining("2. [owner1/project2,owner1/project3]"));
+  expect(parallelExecutionGroup.output).toEqual(expect.stringContaining("3. [owner1/project4]"));
+  
+  // make sure there execution summary for every project and was flushed before exiting
+  expect(result[1].output).toEqual(expect.stringContaining("Execution summary for owner1/project1"));
+  expect(result[1].output).toEqual(expect.stringContaining("Execution summary for owner1/project2"));
+  expect(result[1].output).toEqual(expect.stringContaining("Execution summary for owner1/project3"));
+  expect(result[1].output).toEqual(expect.stringContaining("Execution summary for owner1/project4"));
+  // last line of logs to check stdout was flushed
+  expect(result[1].output).toEqual(expect.stringContaining("No artifacts to archive"));
+});

--- a/test/e2e/parallel/parallel-execution.yaml
+++ b/test/e2e/parallel/parallel-execution.yaml
@@ -1,0 +1,15 @@
+name: Parallel
+
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./build-chain
+        with:
+          definition-file: build-chain/.github/definition-file.yaml
+          flow-type: full_downstream
+          enable-parallel-execution: true
+      - name: clean up
+        run: rm -rf owner1_* && rm -rf project*

--- a/test/unitary/bin/cli-runner.test.ts
+++ b/test/unitary/bin/cli-runner.test.ts
@@ -85,6 +85,7 @@ describe("execute:build", () => {
     const preSpy = jest.spyOn(PreExecutor.prototype, "run").mockImplementation(async () => [okResult]);
     const postSpy = jest.spyOn(PostExecutor.prototype, "run").mockImplementation(async () => [okResult, okResult, okResult]);
     const flowSpy = jest.spyOn(FlowService.prototype, "run").mockImplementation(async () => flowOk);
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation((_code?: number) => undefined as never);
 
     await cliRunner.execute();
 
@@ -92,6 +93,7 @@ describe("execute:build", () => {
     expect(preSpy).toHaveBeenCalledTimes(1);
     expect(postSpy).toHaveBeenCalledTimes(1);
     expect(flowSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   test("failure: pre", async () => {

--- a/test/unitary/bin/github-action-runner.test.ts
+++ b/test/unitary/bin/github-action-runner.test.ts
@@ -84,6 +84,7 @@ describe("execute", () => {
     const preSpy = jest.spyOn(PreExecutor.prototype, "run").mockImplementation(async () => [okResult]);
     const postSpy = jest.spyOn(PostExecutor.prototype, "run").mockImplementation(async () => [okResult, okResult, okResult]);
     const flowSpy = jest.spyOn(FlowService.prototype, "run").mockImplementation(async () => flowOk);
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation((_code?: number) => undefined as never);
     const jobSummarySpy = jest
       .spyOn(JobSummaryService.prototype, "generateSummary")
       .mockImplementation(async (_flowResult: FlowResult, _preResult: ExecuteCommandResult[], _postResult: ExecuteCommandResult[]) => undefined);
@@ -95,6 +96,7 @@ describe("execute", () => {
     expect(postSpy).toHaveBeenCalledTimes(1);
     expect(flowSpy).toHaveBeenCalledTimes(1);
     expect(jobSummarySpy).toHaveBeenCalledWith(flowOk, [okResult], [okResult, okResult, okResult]);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   test("failure: pre", async () => {

--- a/test/unitary/service/arguments/action/action-argument.test.ts
+++ b/test/unitary/service/arguments/action/action-argument.test.ts
@@ -10,6 +10,7 @@ const definitionFile = "/path/to/file";
 const skipProject = ["project1", "project2", "project3"];
 const skipAll = true;
 const skipParallelCheckout = false;
+const enableParallelExecution = false;
 const startProject = "project4";
 const fakeFlagValue = "abc";
 const additionaFlags = `--tempFlag;-z ${fakeFlagValue}`;
@@ -27,6 +28,7 @@ const setGeneralInputs = (flowType: string) => {
     "INPUT_ADDITIONAL-FLAGS": additionaFlags,
     "INPUT_FLOW-TYPE": flowType,
     "INPUT_CUSTOM-COMMAND-TREATMENT": customCommandTreatment.join(", "),
+    "INPUT_ENABLE-PARALLEL-EXECUTION": enableParallelExecution.toString()
   };
 };
 
@@ -49,6 +51,7 @@ describe("Different flow types", () => {
       expect(vals.skipExecution).toBe(skipAll);
       expect(vals.skipCheckout).toBe(skipAll);
       expect(vals.skipParallelCheckout).toBe(skipParallelCheckout);
+      expect(vals.enableParallelExecution).toBe(enableParallelExecution);
       expect(vals.startProject).toBe(startProject);
       expect(vals.tempFlag).toBe(true);
       expect(vals.z).toBe("abc");
@@ -80,6 +83,7 @@ describe("Different log levels", () => {
       expect(vals.skipExecution).toBe(skipAll);
       expect(vals.skipCheckout).toBe(skipAll);
       expect(vals.skipParallelCheckout).toBe(skipParallelCheckout);
+      expect(vals.enableParallelExecution).toBe(enableParallelExecution);
       expect(vals.startProject).toBe(startProject);
       expect(vals.tempFlag).toBe(true);
       expect(vals.z).toBe("abc");

--- a/test/unitary/service/arguments/cli/build-branch.test.ts
+++ b/test/unitary/service/arguments/cli/build-branch.test.ts
@@ -37,6 +37,7 @@ describe("build branch flow cli", () => {
     expect(option.skipExecution).toBe(false);
     expect(option.skipCheckout).toBe(false);
     expect(option.skipParallelCheckout).toBe(false);
+    expect(option.enableParallelExecution).toBe(false);
     expect(option.fullProjectDependencyTree).toBe(false);
 
     // check that the executed command info is set correctly
@@ -98,6 +99,7 @@ describe("build branch flow cli", () => {
         "--skipExecution",
         "--skipCheckout",
         "--fullProjectDependencyTree",
+        "--enableParallelExecution"
       ],
       { from: "user" }
     );
@@ -110,6 +112,7 @@ describe("build branch flow cli", () => {
     expect(option.skipExecution).toBe(true);
     expect(option.skipCheckout).toBe(true);
     expect(option.skipParallelCheckout).toBe(true);
+    expect(option.enableParallelExecution).toBe(true);
     expect(option.fullProjectDependencyTree).toBe(true);
     expect(option.startProject).toBe(startProject);
     expect(option.token).toStrictEqual([token, token]);

--- a/test/unitary/service/arguments/cli/build-cross_pr.test.ts
+++ b/test/unitary/service/arguments/cli/build-cross_pr.test.ts
@@ -34,6 +34,7 @@ describe("build cross pull request flow cli", () => {
     expect(option.loggerLevel).toBe(LoggerLevel.INFO);
     expect(option.skipExecution).toBe(false);
     expect(option.skipCheckout).toBe(false);
+    expect(option.enableParallelExecution).toBe(false);
     expect(option.skipParallelCheckout).toBe(false);
 
     // check that the executed command info is set correctly
@@ -86,6 +87,7 @@ describe("build cross pull request flow cli", () => {
         "--debug",
         "--skipParallelCheckout",
         "--skipExecution",
+        "--enableParallelExecution"
       ],
       { from: "user" }
     );
@@ -99,6 +101,7 @@ describe("build cross pull request flow cli", () => {
     expect(option.skipExecution).toBe(true);
     expect(option.skipCheckout).toBe(true);
     expect(option.skipParallelCheckout).toBe(true);
+    expect(option.enableParallelExecution).toBe(true);
     expect(option.startProject).toBe(startProject);
     expect(option.token).toStrictEqual([token]);
     expect(option.customCommandTreatment).toStrictEqual(customCommandTreatment);

--- a/test/unitary/service/arguments/cli/build-fd.test.ts
+++ b/test/unitary/service/arguments/cli/build-fd.test.ts
@@ -35,6 +35,7 @@ describe("build full downstream pull request flow cli", () => {
     expect(option.skipExecution).toBe(false);
     expect(option.skipCheckout).toBe(false);
     expect(option.skipParallelCheckout).toBe(false);
+    expect(option.enableParallelExecution).toBe(false);
 
     // check that the executed command info is set correctly
     expect(option.CLICommand).toBe(CLIActionType.BUILD);
@@ -88,6 +89,7 @@ describe("build full downstream pull request flow cli", () => {
         "--skipParallelCheckout",
         "--skipExecution",
         "--skipCheckout",
+        "--enableParallelExecution"
       ],
       { from: "user" }
     );
@@ -101,6 +103,7 @@ describe("build full downstream pull request flow cli", () => {
     expect(option.skipExecution).toBe(true);
     expect(option.skipCheckout).toBe(true);
     expect(option.skipParallelCheckout).toBe(true);
+    expect(option.enableParallelExecution).toBe(true);
     expect(option.startProject).toBe(startProject);
     expect(option.token).toStrictEqual([token, token]);
     expect(option.customCommandTreatment).toStrictEqual(customCommandTreatment);

--- a/test/unitary/service/arguments/cli/build-single.test.ts
+++ b/test/unitary/service/arguments/cli/build-single.test.ts
@@ -35,6 +35,7 @@ describe("build single pull request flow cli", () => {
     expect(option.skipExecution).toBe(false);
     expect(option.skipCheckout).toBe(false);
     expect(option.skipParallelCheckout).toBe(false);
+    expect(option.enableParallelExecution).toBe(false);
 
     // check that the executed command info is set correctly
     expect(option.CLICommand).toBe(CLIActionType.BUILD);
@@ -86,6 +87,7 @@ describe("build single pull request flow cli", () => {
         "--skipParallelCheckout",
         "--skipExecution",
         "--skipCheckout",
+        "--enableParallelExecution"
       ],
       { from: "user" }
     );
@@ -99,6 +101,7 @@ describe("build single pull request flow cli", () => {
     expect(option.skipExecution).toBe(true);
     expect(option.skipCheckout).toBe(true);
     expect(option.skipParallelCheckout).toBe(true);
+    expect(option.enableParallelExecution).toBe(true);
     expect(option.startProject).toBe(startProject);
     expect(option.token).toStrictEqual([token]);
     expect(option.customCommandTreatment).toStrictEqual(customCommandTreatment);

--- a/test/unitary/service/artifacts/artifact-service.test.ts
+++ b/test/unitary/service/artifacts/artifact-service.test.ts
@@ -17,6 +17,7 @@ const nodeChain: Node[] = [
     project: "owner1/project1",
     parents: [],
     children: [],
+    depth: -1,
     archiveArtifacts: {
       name: "artifacts-project1",
       dependencies: "all",
@@ -28,6 +29,7 @@ const nodeChain: Node[] = [
     project: "owner2/project2",
     parents: [],
     children: [],
+    depth: -1,
     archiveArtifacts: {
       name: "artifacts-project1",
       dependencies: "none",
@@ -39,6 +41,7 @@ const nodeChain: Node[] = [
     project: "owner3/project3",
     parents: [],
     children: [],
+    depth: -1,
     archiveArtifacts: {
       name: "artifacts-project1",
       dependencies: ["owner1/project1"],

--- a/test/unitary/service/checkout/helpers.ts
+++ b/test/unitary/service/checkout/helpers.ts
@@ -8,6 +8,7 @@ export const nodeChain: Node[] = [
     project: "owner1/project1",
     parents: [],
     children: [],
+    depth: -1,
     clone: ["clone-1", "clone-2"],
     mapping: {
       dependant: {
@@ -23,6 +24,7 @@ export const nodeChain: Node[] = [
     project: "owner2/project2",
     parents: [],
     children: [],
+    depth: -1,
     mapping: {
       exclude: [],
       dependant: {
@@ -46,6 +48,7 @@ export const nodeChain: Node[] = [
   },
   {
     project: "owner3/project3",
+    depth: -1,
     parents: [],
     children: []
   },

--- a/test/unitary/service/command/execute-command-service.test.ts
+++ b/test/unitary/service/command/execute-command-service.test.ts
@@ -59,14 +59,14 @@ describe("ExecuteCommandService", () => {
     const executeCommandService = new ExecuteCommandService(commandTreatmentDelegator, commandExecutorDelegator, configurationService);
 
     // Act
-    const executeCommandResultPromise = await executeCommandService.executeCommand("command X", "cwd");
+    const executeCommandResultPromise = await executeCommandService.executeCommand("command X", { cwd: "cwd" });
 
     // Assert
     expect(executeCommandResultPromise).toStrictEqual({ result: ExecutionResult.OK });
     expect(CommandTreatmentDelegator.prototype.treatCommand).toHaveBeenCalledTimes(1);
     expect(CommandTreatmentDelegator.prototype.treatCommand).toHaveBeenCalledWith("command X", "treatmentOptions");
     expect(CommandExecutorDelegator.prototype.executeCommand).toHaveBeenCalledTimes(1);
-    expect(CommandExecutorDelegator.prototype.executeCommand).toHaveBeenCalledWith("command x treated", "cwd");
+    expect(CommandExecutorDelegator.prototype.executeCommand).toHaveBeenCalledWith("command x treated", {cwd: "cwd"});
   });
 });
 
@@ -141,7 +141,7 @@ describe("executeNodeCommands", () => {
     expect(commandExecutorDelegator.executeCommand).toHaveBeenCalledTimes(expectedCalls.length);
     expect(commandTreatmentDelegator.treatCommand).toHaveBeenCalledTimes(expectedCalls.length);
     expectedCalls.forEach(call => expect(commandTreatmentDelegator.treatCommand).toHaveBeenCalledWith(call, undefined));
-    expectedCalls.forEach(_call => expect(commandExecutorDelegator.executeCommand).toHaveBeenCalledWith(undefined, cwd));
+    expectedCalls.forEach(_call => expect(commandExecutorDelegator.executeCommand).toHaveBeenCalledWith(undefined, { cwd }));
     expect(result.map(res => res.executeCommandResults)).toStrictEqual(
       expectedResult.map(res => (res !== "" ? [{
         startingDate: skipExecution ? expect.any(Number) : 1,

--- a/test/unitary/service/command/execute-command-service.test.ts
+++ b/test/unitary/service/command/execute-command-service.test.ts
@@ -5,16 +5,18 @@ import { CommandExecutorDelegator } from "@bc/service/command/executor/command-e
 import { ExecutionResult } from "@bc/domain/execute-command-result";
 import { ExecutionPhase } from "@bc/domain/execution-phase";
 import { defaultNodeValue } from "@bc/domain/node";
-import { NodeExecutionLevel } from "@bc/domain/node-execution";
+import { NodeExecution, NodeExecutionLevel } from "@bc/domain/node-execution";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
 import { Node } from "@kie/build-chain-configuration-reader";
 import Container from "typedi";
 import { constants } from "@bc/domain/constants";
 import { EntryPoint } from "@bc/domain/entry-point";
+import { ExecuteNodeResult } from "@bc/domain/execute-node-result";
+import { Logger } from "@bc/service/logger/logger";
+import { BaseLoggerService } from "@bc/service/logger/base-logger-service";
 
 // disable logs
 jest.spyOn(global.console, "log");
-jest.mock("@bc/service/logger/base-logger-service");
 jest.mock("@bc/service/command/treatment/command-treatment-delegator");
 jest.mock("@bc/service/command/executor/command-executor-delegator");
 jest.mock("@bc/service/config/configuration-service");
@@ -209,5 +211,106 @@ describe("getNodeCommands", () => {
     };
     const commands = executeCommandService.getNodeCommands(node, ExecutionPhase.AFTER, nodeExecutionLevel);
     expect(commands).toStrictEqual(expectedOutput);
+  });
+});
+
+describe("executeNodeChain", () => {
+  let executeCommandService: ExecuteCommandService;
+  beforeEach(() => {
+    const commandTreatmentDelegator = jest.mocked<CommandTreatmentDelegator>(CommandTreatmentDelegator.prototype, true);
+    const commandExecutorDelegator = jest.mocked<CommandExecutorDelegator>(CommandExecutorDelegator.prototype, true);
+    const configurationService = new ConfigurationService();
+    jest.spyOn(BaseLoggerService.prototype, "logger", "get").mockImplementation(() => ({log: () => undefined, emptyLine: () => undefined}) as Logger);
+
+    executeCommandService = new ExecuteCommandService(commandTreatmentDelegator, commandExecutorDelegator, configurationService);
+  });
+
+  test.each([
+    ["with print results", jest.fn((_node: ExecuteNodeResult[]) => undefined)],
+    ["without print results", undefined]
+  ])("sequential: %p", async (_title, printFn) => {
+    jest.spyOn(ConfigurationService.prototype, "isParallelExecutionEnabled").mockReturnValueOnce(false);
+    const execSpy = jest.spyOn(executeCommandService, "executeNodeCommands").mockResolvedValue([]);
+    
+    const nodeChain: NodeExecution[] = [
+      {
+        node: {
+          ...defaultNodeValue,
+          project: "project1"
+        }
+      },
+      {
+        node: {
+          ...defaultNodeValue,
+          project: "project2"
+        }
+      }
+    ];
+
+    await executeCommandService.executeNodeChain(nodeChain, printFn);
+    expect(execSpy).toHaveBeenCalledTimes(2);
+    if (printFn) {
+      expect(printFn).toHaveBeenCalledTimes(2);
+    }
+  });
+
+  test.each([
+    ["with print results", jest.fn((_node: ExecuteNodeResult[]) => undefined)],
+    ["without print results", undefined]
+  ])("parallel: %p", async (_title, printFn) => {
+    jest.spyOn(ConfigurationService.prototype, "isParallelExecutionEnabled").mockReturnValueOnce(true);
+    const execSpy = jest.spyOn(executeCommandService, "executeNodeCommands").mockResolvedValue([]);
+    const promiseSpy = jest.spyOn(Promise, "all");
+    const nodeChain: NodeExecution[] = [
+      {
+        node: {
+          ...defaultNodeValue,
+          project: "project1",
+          depth: 0
+        }
+      },
+      {
+        node: {
+          ...defaultNodeValue,
+          project: "project2",
+          depth: 1
+        }
+      },
+      {
+        node: {
+          ...defaultNodeValue,
+          project: "project3",
+          depth: 1
+        }
+      },
+      {
+        node: {
+          ...defaultNodeValue,
+          project: "project4",
+          depth: 2
+        }
+      }
+    ];
+
+    await executeCommandService.executeNodeChain(nodeChain, printFn);
+    expect(execSpy).toHaveBeenCalledTimes(4);
+    if (printFn) {
+      expect(printFn).toHaveBeenCalledTimes(4);
+    }
+
+    // check the number of arguments passed to Promise.all
+    expect(promiseSpy.mock.calls[0][0].length).toBe(1);
+    expect(promiseSpy.mock.calls[1][0].length).toBe(2);
+    expect(promiseSpy.mock.calls[2][0].length).toBe(1);
+
+    // first call to execSpy must be for the first node
+    expect(execSpy.mock.calls[0][0]).toStrictEqual(nodeChain[0]);
+    
+    // the second and third execSpy must be for 2nd and 3rd node (can be in any order due to promises)
+    expect([execSpy.mock.calls[1][0], execSpy.mock.calls[2][0]]).toContain(nodeChain[1]);
+    expect([execSpy.mock.calls[1][0], execSpy.mock.calls[2][0]]).toContain(nodeChain[2]);
+    
+    // last call to execSpy must be for the last node
+    expect(execSpy.mock.calls[3][0]).toStrictEqual(nodeChain[3]);
   });
 });

--- a/test/unitary/service/command/executor/bash-executor.test.ts
+++ b/test/unitary/service/command/executor/bash-executor.test.ts
@@ -11,7 +11,7 @@ describe("Bash Executor", () => {
     (exec as jest.Mocked<typeof exec>).exec.mockResolvedValueOnce(Promise.resolve(0));
 
     // Act
-    await bashExecutor.execute("command x", "whateverthepath");
+    await bashExecutor.execute("command x", {cwd: "whateverthepath"});
 
     // Arrange
     expect(exec.exec).toHaveBeenCalledTimes(1);
@@ -28,7 +28,7 @@ describe("Bash Executor", () => {
 
     // Arrange
     expect(exec.exec).toHaveBeenCalledTimes(1);
-    expect(exec.exec).toHaveBeenCalledWith("command x", [], { cwd: undefined });
+    expect(exec.exec).toHaveBeenCalledWith("command x", [], undefined);
   });
 });
 

--- a/test/unitary/service/command/executor/command-executor-delegator.test.ts
+++ b/test/unitary/service/command/executor/command-executor-delegator.test.ts
@@ -4,7 +4,6 @@ import { BashExecutor } from "@bc/service/command/executor/bash-executor";
 import { ExportExecutor } from "@bc/service/command/executor/export-executor";
 import { ExecutionResult } from "@bc/domain/execute-command-result";
 import { hrtimeToMs } from "@bc/utils/date";
-import { BaseLoggerService } from "@bc/service/logger/base-logger-service";
 import Container from "typedi";
 import { constants } from "@bc/domain/constants";
 import { EntryPoint } from "@bc/domain/entry-point";
@@ -76,7 +75,7 @@ describe("isExport", () => {
     (hrtimeToMs as jest.Mocked<jest.Mock>).mockReturnValue(2000);
 
     // Act
-    const result = await commandExecutorDelegator.executeCommand(command, cwd);
+    const result = await commandExecutorDelegator.executeCommand(command, { cwd });
 
     // Assert
     expect(result).toStrictEqual({
@@ -89,7 +88,7 @@ describe("isExport", () => {
     });
     expect(bashExecutor.execute).toHaveBeenCalledTimes(0);
     expect(exportExecutor.execute).toHaveBeenCalledTimes(1);
-    expect(exportExecutor.execute).toHaveBeenCalledWith(command, cwd);
+    expect(exportExecutor.execute).toHaveBeenCalledWith(command, { cwd });
   });
 
   test("Error", async () => {
@@ -120,8 +119,6 @@ describe("isExport", () => {
     expect(bashExecutor.execute).toHaveBeenCalledTimes(0);
     expect(exportExecutor.execute).toHaveBeenCalledTimes(1);
     expect(exportExecutor.execute).toHaveBeenCalledWith(command, undefined);
-    expect(BaseLoggerService.prototype.error).toHaveBeenCalledTimes(1);
-    expect(BaseLoggerService.prototype.error).toHaveBeenCalledWith(`Error executing command ${command}. ${errorMessage}`);
   });
 });
 
@@ -171,7 +168,7 @@ describe("not export command", () => {
     (hrtimeToMs as jest.Mocked<jest.Mock>).mockReturnValue(1000);
 
     // Act
-    const result = await commandExecutorDelegator.executeCommand(command, cwd);
+    const result = await commandExecutorDelegator.executeCommand(command, { cwd });
 
     // Assert
     expect(result).toStrictEqual({
@@ -184,7 +181,7 @@ describe("not export command", () => {
     });
     expect(bashExecutor.execute).toHaveBeenCalledTimes(1);
     expect(exportExecutor.execute).toHaveBeenCalledTimes(0);
-    expect(bashExecutor.execute).toHaveBeenCalledWith(command, cwd);
+    expect(bashExecutor.execute).toHaveBeenCalledWith(command, { cwd });
   });
 
   test("Error", async () => {
@@ -215,7 +212,5 @@ describe("not export command", () => {
     expect(bashExecutor.execute).toHaveBeenCalledTimes(1);
     expect(exportExecutor.execute).toHaveBeenCalledTimes(0);
     expect(bashExecutor.execute).toHaveBeenCalledWith(command, undefined);
-    expect(BaseLoggerService.prototype.error).toHaveBeenCalledTimes(1);
-    expect(BaseLoggerService.prototype.error).toHaveBeenCalledWith(`Error executing command ${command}. ${errorMessage}`);
   });
 });

--- a/test/unitary/service/command/executor/export-executor.test.ts
+++ b/test/unitary/service/command/executor/export-executor.test.ts
@@ -24,7 +24,7 @@ describe("Export Command Executor", () => {
 
     // Act
     try {
-      await exportCommandExecutor.execute("command x", "whateverthepath");
+      await exportCommandExecutor.execute("command x", {cwd: "whateverthepath"});
       expect(true).toBe(false);
     } catch (ex: unknown) {
       expect((ex as Error).message).toBe("The export command command x is not properly defined. It should be something like \"export VARIBLE=expression\". Please fix it an try again.");
@@ -42,7 +42,7 @@ describe("Export Command Executor", () => {
     (exec as jest.Mocked<typeof exec>).exec.mockResolvedValueOnce(Promise.resolve(0));
 
     // Act
-    await exportCommandExecutor.execute("export VARIABLE1=newvalue", "whateverthepath");
+    await exportCommandExecutor.execute("export VARIABLE1=newvalue", {cwd: "whateverthepath"});
 
     // Arrange
     expect(exec.exec).toHaveBeenCalledTimes(0);
@@ -58,7 +58,7 @@ describe("Export Command Executor", () => {
     (exec as jest.Mocked<typeof exec>).exec.mockResolvedValueOnce(Promise.resolve(0));
 
     // Act
-    await exportCommandExecutor.execute("export VARIABLE2=\"VALUE1 VALUE 2\"", "whateverthepath");
+    await exportCommandExecutor.execute("export VARIABLE2=\"VALUE1 VALUE 2\"", {cwd: "whateverthepath"});
 
     // Arrange
     expect(exec.exec).toHaveBeenCalledTimes(0);
@@ -74,7 +74,7 @@ describe("Export Command Executor", () => {
     (exec as jest.Mocked<typeof exec>).exec.mockResolvedValueOnce(Promise.resolve(0));
 
     // Act
-    await exportCommandExecutor.execute("export VARIABLE3='VALUE1 VALUE 2'", "whateverthepath");
+    await exportCommandExecutor.execute("export VARIABLE3='VALUE1 VALUE 2'", {cwd: "whateverthepath"});
 
     // Arrange
     expect(exec.exec).toHaveBeenCalledTimes(0);
@@ -90,7 +90,7 @@ describe("Export Command Executor", () => {
     (exec as jest.Mocked<typeof exec>).exec.mockResolvedValueOnce(Promise.resolve(0));
 
     // Act
-    await exportCommandExecutor.execute("export VARIABLE4=`whateverthecommand`", "whateverthepath");
+    await exportCommandExecutor.execute("export VARIABLE4=`whateverthecommand`", {cwd: "whateverthepath"});
 
     // Arrange
     expect(exec.exec).toHaveBeenCalledTimes(1);
@@ -108,7 +108,7 @@ describe("Export Command Executor", () => {
 
     // Act
     try {
-      await exportCommandExecutor.execute("whatever the command", "whateverthepath");
+      await exportCommandExecutor.execute("whatever the command", {cwd: "whateverthepath"});
       expect(false).toBe(true);
     } catch (ex: unknown) {
       expect((ex as Error).message).toBe("The export command whatever the command is not properly defined. It should be something like \"export VARIBLE=expression\". Please fix it an try again.");

--- a/test/unitary/service/config/configuration-service.test.ts
+++ b/test/unitary/service/config/configuration-service.test.ts
@@ -344,6 +344,13 @@ describe("methods", () => {
     );
   });
 
+  test("isParallelExecutionEnabled", () => {
+    currentInput = { ...defaultInputValues, enableParallelExecution: true };
+    expect(config.isParallelExecutionEnabled()).toBe(
+      currentInput.enableParallelExecution
+    );
+  });
+
   test("getPre", () => {
     jest
       .spyOn(ConfigurationService.prototype, "definitionFile", "get")

--- a/test/unitary/service/pre-post/post.test.ts
+++ b/test/unitary/service/pre-post/post.test.ts
@@ -7,6 +7,7 @@ import { EntryPoint } from "@bc/domain/entry-point";
 import * as core from "@actions/core";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
 import { ExecuteCommandResult, ExecutionResult } from "@bc/domain/execute-command-result";
+import { ExecOptions } from "@actions/exec";
 
 // just for initialization otherwise not relevant to testing
 Container.set(constants.CONTAINER.ENTRY_POINT, EntryPoint.GITHUB_EVENT);
@@ -45,11 +46,11 @@ describe("On success", () => {
         success: cmds,
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _opts?: ExecOptions) => emptyCommandResult);
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(executedCmds.length);
     executedCmds.forEach(cmd => {
-      expect(execSpy).toHaveBeenCalledWith(cmd, process.cwd());
+      expect(execSpy).toHaveBeenCalledWith(cmd, {cwd: process.cwd()});
     });
   });
 
@@ -63,11 +64,11 @@ describe("On success", () => {
         always: cmds,
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _opts?: ExecOptions) => emptyCommandResult);
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(executedCmds.length * 2);
     [...executedCmds, ...executedCmds].forEach(cmd => {
-      expect(execSpy).toHaveBeenCalledWith(cmd, process.cwd());
+      expect(execSpy).toHaveBeenCalledWith(cmd, {cwd: process.cwd()});
     });
   });
 
@@ -77,7 +78,7 @@ describe("On success", () => {
         failure: ["cmd"],
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _opts?: ExecOptions) => emptyCommandResult);
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(0);
   });
@@ -104,11 +105,11 @@ describe("On failure", () => {
         failure: cmds,
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _opts?: ExecOptions) => emptyCommandResult);
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(executedCmds.length);
     executedCmds.forEach(cmd => {
-      expect(execSpy).toHaveBeenCalledWith(cmd, process.cwd());
+      expect(execSpy).toHaveBeenCalledWith(cmd, {cwd: process.cwd()});
     });
   });
 
@@ -122,12 +123,12 @@ describe("On failure", () => {
         always: cmds,
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _opts?: ExecOptions) => emptyCommandResult);
 
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(executedCmds.length * 2);
     [...executedCmds, ...executedCmds].forEach(cmd => {
-      expect(execSpy).toHaveBeenCalledWith(cmd, process.cwd());
+      expect(execSpy).toHaveBeenCalledWith(cmd, {cwd: process.cwd()});
     });
   });
 
@@ -137,7 +138,7 @@ describe("On failure", () => {
         success: ["cmd"],
       };
     });
-    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
+    const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _opts?: ExecOptions) => emptyCommandResult);
 
     await post.run();
     expect(execSpy).toHaveBeenCalledTimes(0);
@@ -148,7 +149,7 @@ test("no post", async () => {
   jest.spyOn(ConfigurationService.prototype, "getPost").mockImplementationOnce(() => {
     return {};
   });
-  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _cwd?: string) => emptyCommandResult);
+  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementationOnce(async (_cmd: string, _opts?: ExecOptions) => emptyCommandResult);
   const post = Container.get(PostExecutor);
   await post.run();
   expect(execSpy).toHaveBeenCalledTimes(0);

--- a/test/unitary/service/pre-post/pre.test.ts
+++ b/test/unitary/service/pre-post/pre.test.ts
@@ -8,6 +8,7 @@ import { ExecuteCommandService } from "@bc/service/command/execute-command-servi
 import * as core from "@actions/core";
 import { ConfigurationService } from "@bc/service/config/configuration-service";
 import { ExecuteCommandResult, ExecutionResult } from "@bc/domain/execute-command-result";
+import { ExecOptions } from "@actions/exec";
 
 // just for initialization otherwise not relevant to testing
 Container.set(constants.CONTAINER.ENTRY_POINT, EntryPoint.GITHUB_EVENT);
@@ -31,18 +32,18 @@ test.each([
   ["multiple commands", ["cmd1", "cmd2"], ["cmd1", "cmd2"]],
 ])("%p", async (_title: string, cmds: Pre, executedCmds: string[]) => {
   jest.spyOn(ConfigurationService.prototype, "getPre").mockImplementation(() => cmds);
-  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementation(async (_cmd: string, _cwd?: string) => emptyCommandResult);
+  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementation(async (_cmd: string, _opts?: ExecOptions) => emptyCommandResult);
   const pre = Container.get(PreExecutor);
   await pre.run();
   expect(execSpy).toHaveBeenCalledTimes(executedCmds.length);
   executedCmds.forEach(cmd => {
-    expect(execSpy).toHaveBeenCalledWith(cmd, process.cwd());
+    expect(execSpy).toHaveBeenCalledWith(cmd, {cwd: process.cwd()});
   });
 });
 
 test("no pre", async () => {
   jest.spyOn(ConfigurationService.prototype, "getPre").mockImplementation(() => undefined);
-  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementation(async (_cmd: string, _cwd?: string) => emptyCommandResult);
+  const execSpy = jest.spyOn(ExecuteCommandService.prototype, "executeCommand").mockImplementation(async (_cmd: string, _opts?: ExecOptions) => emptyCommandResult);
   const pre = Container.get(PreExecutor);
   await pre.run();
   expect(execSpy).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
fixes #427 

Some of the manual test cases I tried with parallelism enabled would only print 3/4th's of the logs. To fix this I had to implement a safe exit for the runners to force them to wait for stdout to be flushed before exiting. 