### PR TITLE
Update build-chain-configuration-reader to 3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",
         "@actions/core": "^1.8.2",
         "@actions/exec": "^1.1.1",
         "@actions/glob": "^0.3.0",
-        "@kie/build-chain-configuration-reader": "^3.0.16",
+        "@kie/build-chain-configuration-reader": "^3.1.3",
         "@octokit/plugin-throttling": "^5.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/rest": "^18.12.0",
@@ -1218,9 +1218,9 @@
       "dev": true
     },
     "node_modules/@kie/build-chain-configuration-reader": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.16.tgz",
-      "integrity": "sha512-rC1RZKckjB/Sw9TsZBQZnXAKLra/zf5I56W0uOVaqNg/CNTYoA9BpIqkrL7cH8Toc0yA7yJiqY/cqWeUuvwwTA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.1.3.tgz",
+      "integrity": "sha512-JPuRaACiAgwXF72pkb1iQJ/85/I1mrFIdSsdkdstcp7ORuHJWWmj2bDxb97YwjCj2fQdiHj9RhPdJ8GADHWFbA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "axios": "^0.27.2",
@@ -8546,9 +8546,9 @@
       }
     },
     "@kie/build-chain-configuration-reader": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.0.16.tgz",
-      "integrity": "sha512-rC1RZKckjB/Sw9TsZBQZnXAKLra/zf5I56W0uOVaqNg/CNTYoA9BpIqkrL7cH8Toc0yA7yJiqY/cqWeUuvwwTA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.1.3.tgz",
+      "integrity": "sha512-JPuRaACiAgwXF72pkb1iQJ/85/I1mrFIdSsdkdstcp7ORuHJWWmj2bDxb97YwjCj2fQdiHj9RhPdJ8GADHWFbA==",
       "requires": {
         "ajv": "^8.11.0",
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",
@@ -62,7 +62,7 @@
     "@actions/core": "^1.8.2",
     "@actions/exec": "^1.1.1",
     "@actions/glob": "^0.3.0",
-    "@kie/build-chain-configuration-reader": "^3.0.16",
+    "@kie/build-chain-configuration-reader": "^3.1.3",
     "@octokit/plugin-throttling": "^5.0.1",
     "@octokit/request-error": "^2.1.0",
     "@octokit/rest": "^18.12.0",


### PR DESCRIPTION
There is a new release of build-chain-configuration-reader. Verify that there are no breaking changes