### PR TITLE
Update build-chain-configuration-reader to 3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",
         "@actions/core": "^1.8.2",
         "@actions/exec": "^1.1.1",
         "@actions/glob": "^0.3.0",
-        "@kie/build-chain-configuration-reader": "^3.1.3",
+        "@kie/build-chain-configuration-reader": "^3.1.4",
         "@octokit/plugin-throttling": "^5.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/rest": "^18.12.0",
@@ -1219,9 +1219,9 @@
       "dev": true
     },
     "node_modules/@kie/build-chain-configuration-reader": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.1.3.tgz",
-      "integrity": "sha512-JPuRaACiAgwXF72pkb1iQJ/85/I1mrFIdSsdkdstcp7ORuHJWWmj2bDxb97YwjCj2fQdiHj9RhPdJ8GADHWFbA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.1.4.tgz",
+      "integrity": "sha512-2TFlO6JVhkyfOZnRBH3l3/D24PSYun/8szUbeEOzETqXHF6YL5zGWcCb9Qzzz0SAlqAHQzVUimbWh1L3Ci2n5w==",
       "dependencies": {
         "ajv": "^8.11.0",
         "axios": "^0.27.2",
@@ -8545,9 +8545,9 @@
       }
     },
     "@kie/build-chain-configuration-reader": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.1.3.tgz",
-      "integrity": "sha512-JPuRaACiAgwXF72pkb1iQJ/85/I1mrFIdSsdkdstcp7ORuHJWWmj2bDxb97YwjCj2fQdiHj9RhPdJ8GADHWFbA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@kie/build-chain-configuration-reader/-/build-chain-configuration-reader-3.1.4.tgz",
+      "integrity": "sha512-2TFlO6JVhkyfOZnRBH3l3/D24PSYun/8szUbeEOzETqXHF6YL5zGWcCb9Qzzz0SAlqAHQzVUimbWh1L3Ci2n5w==",
       "requires": {
         "ajv": "^8.11.0",
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",
@@ -62,7 +62,7 @@
     "@actions/core": "^1.8.2",
     "@actions/exec": "^1.1.1",
     "@actions/glob": "^0.3.0",
-    "@kie/build-chain-configuration-reader": "^3.1.3",
+    "@kie/build-chain-configuration-reader": "^3.1.4",
     "@octokit/plugin-throttling": "^5.0.1",
     "@octokit/request-error": "^2.1.0",
     "@octokit/rest": "^18.12.0",


### PR DESCRIPTION
There is a new release of build-chain-configuration-reader. Verify that there are no breaking changes