### PR TITLE
fix: project id in changes API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/src/service/git/gerrit-api-client.ts
+++ b/src/service/git/gerrit-api-client.ts
@@ -64,7 +64,6 @@ export class GerritAPIClient extends BaseGitAPIClient {
   }
 
   private async listPulls(args: Pulls["list"]["parameters"]) {
-    const projectId = this.getProjectId(args.owner, args.repo);
     let state;
     switch (args.state) {
       case "opened":
@@ -76,14 +75,14 @@ export class GerritAPIClient extends BaseGitAPIClient {
     }
 
     // looks like gerrit does not have any query for head branch
-    let query = `project:${projectId}`;
+    let query = `project:${args.owner}/${args.repo}`;
     if (state) {
       query += `+status:${state}`;
     }
     if (args.base) {
       query += `+branch:${args.base}`;
     }
-    const { data, status } = await this.client.get("/changes", {
+    const { data, status } = await this.client.get("/changes/", {
       params: {
         q: query,
       },

--- a/test/unitary/service/git/gerrit-client.test.ts
+++ b/test/unitary/service/git/gerrit-client.test.ts
@@ -153,9 +153,9 @@ describe("pulls", () => {
         state: state as unknown as "opened" | "closed" | "merged",
       })
     ).resolves.toStrictEqual({ data: ["data"], status: 200 });
-    expect(getSpy).toHaveBeenCalledWith("/changes", {
+    expect(getSpy).toHaveBeenCalledWith("/changes/", {
       params: {
-        q: `project:${encodeURIComponent(`${owner}/${repo}`)}+${expectedQuery}`,
+        q: `project:${owner}/${repo}+${expectedQuery}`,
       },
     });
   });


### PR DESCRIPTION
Fixes a bug in gerrit's change API - need the project id to not be url encoded in the query param