### PR TITLE
fix: validate workspace against state file before resuming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/src/service/git/git-cli.ts
+++ b/src/service/git/git-cli.ts
@@ -163,4 +163,8 @@ export class GitCLIService {
     }
     await this.git(cwd).push("origin", branch, options);
   }
+
+  async branch(cwd: string) {
+    return this.git(cwd).branch();
+  }
 }

--- a/test/unitary/service/tools/resume.test.ts
+++ b/test/unitary/service/tools/resume.test.ts
@@ -14,49 +14,145 @@ import { FlowService } from "@bc/service/flow/flow-service";
 import { ExecutionResult } from "@bc/domain/execute-command-result";
 import { CLIConfiguration } from "@bc/service/config/cli-configuration";
 import path from "path";
+import { MockGithub } from "@kie/mock-github";
+import { GitCLIService } from "@bc/service/git/git-cli";
+import { BranchSummary } from "simple-git";
 
 Container.set(constants.CONTAINER.ENTRY_POINT, EntryPoint.CLI);
-jest.spyOn(global.console, "log");
 
 let resume: Resume;
 beforeEach(() => {
   resume = new Resume();
+  jest.spyOn(global.console, "log").mockImplementation(() => undefined);
+  jest
+    .spyOn(CLIConfiguration.prototype, "loadToken")
+    .mockImplementation(() => undefined);
+  delete process.env["GITHUB_REPOSITORY"];
 });
 
-test("execute", async () => {
-  jest.spyOn(fs, "readFileSync").mockReturnValue(
-    JSON.stringify({
-      configurationService: {
-        configuration: {
-          _gitEventData: {
-            base: {
-              repo: {
-                full_name: "test"
-              }
-            }
+describe("execute", () => {
+  let cliSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({
+        configurationService: {
+          configuration: {
+            _gitEventData: {
+              base: {
+                repo: {
+                  full_name: "test",
+                },
+              },
+            },
+            _gitConfiguration: {},
+            _sourceProject: {},
+            _targetProject: {},
+            _parsedInputs: {
+              CLISubCommand: FlowType.BRANCH,
+            },
+            _defaultPlatform: PlatformType.GITLAB,
           },
-          _gitConfiguration: {},
-          _sourceProject: {},
-          _targetProject: {},
-          _parsedInputs: {
-            CLISubCommand: FlowType.BRANCH,
+          _nodeChain: [{ project: "test" }],
+          _definitionFile: {
+            version: 2.3,
+            build: [],
           },
-          _defaultPlatform: PlatformType.GITLAB,
         },
-        _nodeChain: [{ project: "test" }],
-        _definitionFile: {
-          version: 2.3,
-          build: [],
+        checkoutService: [
+          {
+            node: { project: "test" },
+            checkoutInfo: { merge: false, repoDir: "dir" },
+            checkedOut: true,
+          },
+        ],
+        flowService: [
+          [
+            {
+              node: {
+                project: "test",
+              },
+              executeCommandResults: [
+                {
+                  command: "false",
+                  result: ExecutionResult.OK,
+                  errorMessage: "",
+                },
+              ],
+            },
+            {
+              node: {
+                project: "test",
+              },
+              executeCommandResults: [
+                {
+                  command: "false",
+                  result: ExecutionResult.OK,
+                  errorMessage: "",
+                },
+              ],
+            },
+            {
+              node: {
+                project: "test",
+              },
+              executeCommandResults: [
+                {
+                  command: "false",
+                  result: ExecutionResult.OK,
+                  errorMessage: "",
+                },
+              ],
+            },
+          ],
+        ],
+      })
+    );
+    cliSpy = jest
+      .spyOn(CLIRunner.prototype, "execute")
+      .mockImplementation(async () => undefined);
+    jest
+      .spyOn(GitCLIService.prototype, "branch")
+      .mockResolvedValue({} as BranchSummary);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("cli runner to have been called", async () => {
+    await resume.execute();
+    expect(cliSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("config service successfully reconstructed and patched", async () => {
+    await resume.execute();
+    const configService = Container.get(ConfigurationService);
+    expect(configService.init()).resolves.toBe(undefined);
+    expect(configService.getFlowType()).toBe(FlowType.BRANCH);
+    expect(configService.getRootFolder()).toBe(process.cwd());
+  });
+
+  test("checkout service successfully reconstructed", async () => {
+    await resume.execute();
+    const checkoutService = Container.get(CheckoutService);
+    expect(checkoutService.checkoutDefinitionTree()).resolves.toMatchObject([
+      {
+        node: { project: "test" },
+        checkoutInfo: {
+          merge: false,
+          repoDir: path.join(process.cwd(), "test"),
         },
       },
-      checkoutService: [
-        {
-          node: { project: "test" },
-          checkoutInfo: { merge: false },
-          checkedOut: true,
-        },
-      ],
-      flowService: [
+    ]);
+  });
+
+  test("flow service successfully reconstructed", async () => {
+    await resume.execute();
+    const flowService = Container.get(FlowService);
+    expect(flowService.run()).resolves.toMatchObject({
+      executionResult: [
         [
           {
             node: {
@@ -96,79 +192,154 @@ test("execute", async () => {
           },
         ],
       ],
-    })
-  );
-
-  jest.spyOn(CLIConfiguration.prototype, "loadToken").mockImplementation(() => undefined);
-
-  const cliSpy = jest
-    .spyOn(CLIRunner.prototype, "execute")
-    .mockImplementation(async () => undefined);
-
-  delete process.env["GITHUB_REPOSITORY"];
-
-  await resume.execute();
-
-  expect(cliSpy).toHaveBeenCalledTimes(1);
-
-  const configService = Container.get(ConfigurationService);
-  expect(configService.init()).resolves.toBe(undefined);
-  // test whether deserialization worked
-  expect(configService.getFlowType()).toBe(FlowType.BRANCH);
-  expect(configService.getRootFolder()).toBe(process.cwd());
-
-  const checkoutService = Container.get(CheckoutService);
-  expect(checkoutService.checkoutDefinitionTree()).resolves.toMatchObject([
-    {
-      node: { project: "test" },
-      checkoutInfo: { merge: false, repoDir: path.join(process.cwd(), "test") },
-    }
-  ]);
-
-  const flowService = Container.get(FlowService);
-  expect(flowService.run()).resolves.toMatchObject({
-    executionResult: [
-      [
-        {
-          node: {
-            project: "test",
-          },
-          executeCommandResults: [
-            {
-              command: "false",
-              result: ExecutionResult.OK,
-              errorMessage: "",
-            },
-          ],
-        },
-        {
-          node: {
-            project: "test",
-          },
-          executeCommandResults: [
-            {
-              command: "false",
-              result: ExecutionResult.OK,
-              errorMessage: "",
-            },
-          ],
-        },
-        {
-          node: {
-            project: "test",
-          },
-          executeCommandResults: [
-            {
-              command: "false",
-              result: ExecutionResult.OK,
-              errorMessage: "",
-            },
-          ],
-        },
-      ],
-    ],
+    });
   });
 
-  const args = Container.get(CLIArguments);
-  expect(args.getCommand().parse()).toBe(undefined);
+  test("cli argument service successfully patched", async () => {
+    await resume.execute();
+    const args = Container.get(CLIArguments);
+    expect(args.getCommand().parse()).toBe(undefined);
+  });
+});
+
+describe("verify", () => {
+  let mg: MockGithub;
+
+  beforeEach(async () => {
+    mg = new MockGithub(
+      {
+        repo: {
+          project1: {
+            currentBranch: "branch1",
+          },
+          project2: {
+            pushedBranches: ["branch2"],
+          },
+        },
+      },
+      path.join(__dirname, "setup")
+    );
+    await mg.setup();
+  });
+
+  afterEach(async () => {
+    await mg.teardown();
+    jest.restoreAllMocks();
+  });
+
+  test("verify checkout", async () => {
+    jest.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({
+        configurationService: {
+          configuration: {
+            _gitEventData: {
+              base: {
+                repo: {
+                  full_name: "test",
+                },
+              },
+            },
+            _gitConfiguration: {},
+            _sourceProject: {},
+            _targetProject: {},
+            _parsedInputs: {
+              CLISubCommand: FlowType.BRANCH,
+            },
+            _defaultPlatform: PlatformType.GITLAB,
+          },
+          _nodeChain: [{ project: "test" }],
+          _definitionFile: {
+            version: 2.3,
+            build: [],
+          },
+        },
+        checkoutService: [
+          {
+            node: { project: "project1" },
+            checkoutInfo: {
+              sourceBranch: "branch1",
+              merge: false,
+              repoDir: mg.repo.getPath("project1"),
+            },
+            checkedOut: true,
+          },
+          {
+            node: { project: "project2" },
+            checkoutInfo: {
+              sourceBranch: "branch1",
+              merge: false,
+              repoDir: mg.repo.getPath("project2"),
+            },
+            checkedOut: true,
+          },
+          {
+            node: { project: "project3" },
+            checkoutInfo: {
+              sourceBranch: "branch1",
+              merge: false,
+              repoDir: "project3",
+            },
+            checkedOut: false,
+          },
+          {
+            node: { project: "project4" },
+            checkoutInfo: {
+              sourceBranch: "branch1",
+              merge: false,
+              repoDir: "project4",
+            },
+            checkedOut: true,
+          },
+        ],
+        flowService: [],
+      })
+    );
+
+    jest
+      .spyOn(CLIRunner.prototype, "execute")
+      .mockImplementation(async () => undefined);
+
+    const checkoutServiceSpy = jest.spyOn(CheckoutService, "fromJSON");
+
+    await resume.execute();
+
+    expect(checkoutServiceSpy).toHaveBeenCalledWith([
+      {
+        node: { project: "project1" },
+        checkoutInfo: {
+          sourceBranch: "branch1",
+          merge: false,
+          repoDir: mg.repo.getPath("project1"),
+        },
+        checkedOut: true,
+      },
+      {
+        node: { project: "project2" },
+        checkoutInfo: {
+          sourceBranch: "branch1",
+          merge: false,
+          repoDir: mg.repo.getPath("project2"),
+        },
+        checkedOut: false,
+      },
+      {
+        node: { project: "project3" },
+        checkoutInfo: {
+          sourceBranch: "branch1",
+          merge: false,
+          repoDir: "project3",
+        },
+        checkedOut: false,
+      },
+      {
+        node: { project: "project4" },
+        checkoutInfo: {
+          sourceBranch: "branch1",
+          merge: false,
+          repoDir: "project4",
+        },
+        checkedOut: false,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
fixes #452 

I think the only thing that needs to be verified is the state of the repositories in the workspace. Verifying whether the actual state file is valid or not might defeat the purpose of the `resume` command. So I think we have to operate with the assumption that the user will not make changes to the state file itself.