### PR TITLE
Fix head field used by octokit.rest.pulls.list() method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.5.5",
+      "version": "3.5.6",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",

--- a/src/service/checkout/checkout-service.ts
+++ b/src/service/checkout/checkout-service.ts
@@ -166,7 +166,7 @@ export class CheckoutService implements Serializable<SerializedCheckoutService, 
         const hasPullRequestFromFork = await gitAPIService.hasPullRequest(
           currentTarget.group,
           currentTarget.name,
-          `${originalSource.group}/${forkName}:${originalSource.branch}`,
+          `${originalSource.group}:${originalSource.branch}`,
           currentTarget.mappedBranch
         );
         return { forkName, hasPullRequest: hasPullRequestFromFork };

--- a/test/unitary/service/checkout/checkout-service.test.ts
+++ b/test/unitary/service/checkout/checkout-service.test.ts
@@ -95,8 +95,8 @@ describe.each([
       repo: "project2"
     }).reply({status: 200, data: {}});
 
-    moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner2/project1-forked:sbranch2", base: "tbranch1"}).reply({status: 200, data: [{title: "pr"}]});
-    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2/project2:sbranch2", base: "tbranch2"}).reply({status: 200, data: []});
+    moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner2:sbranch2", base: "tbranch1"}).reply({status: 200, data: [{title: "pr"}]});
+    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:sbranch2", base: "tbranch2"}).reply({status: 200, data: []});
     moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:sbranch2", base: "tbranch2"}).reply({status: 200, data: [{title: "pr"}]});
 
     const checkedOutNodeInfo = await checkoutService.checkoutDefinitionTree();
@@ -170,7 +170,7 @@ describe.each([
     }).reply({status: 200, data: {}});
 
     moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner1:sbranch2", base: "tbranch1"}).reply({status: 200, data: [{title: "pr"}]});
-    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2/project2:sbranch2", base: "tbranch2"}).reply({status: 200, data: []});
+    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:sbranch2", base: "tbranch2"}).reply({status: 200, data: []});
     moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:sbranch2", base: "tbranch2"}).reply({status: 200, data: [{title: "pr"}]});
 
     const checkedOutNodeInfo = await checkoutService.checkoutDefinitionTree();
@@ -243,7 +243,7 @@ describe.each([
     }).reply({status: 200, data: {}});
 
     moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner1:sbranch2", base: "tbranch1"}).reply({status: 200, data: []});
-    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2/project2:sbranch2", base: "tbranch2"}).reply({status: 200, data: []});
+    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:sbranch2", base: "tbranch2"}).reply({status: 200, data: []});
     moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:sbranch2", base: "tbranch2"}).reply({status: 200, data: [{title: "pr"}]});
 
     const checkedOutNodeInfo = await checkoutService.checkoutDefinitionTree();
@@ -344,8 +344,8 @@ describe.each([
       repo: "project2"
     }).reply({status: 200, data: [{name: "project2-forked", owner: {login: "owner4"}}]});
 
-    moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner4/project1-forked:sbranch2-forked", base: "tbranch1"}).reply({status: 200, data: [{title: "pr"}]});
-    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner4/project2-forked:sbranch2-forked", base: "tbranch2"}).reply({status: 200, data: [{title: "pr"}]});
+    moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner4:sbranch2-forked", base: "tbranch1"}).reply({status: 200, data: [{title: "pr"}]});
+    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner4:sbranch2-forked", base: "tbranch2"}).reply({status: 200, data: [{title: "pr"}]});
 
     
     const checkedOutNodeInfo = await checkoutService.checkoutDefinitionTree();
@@ -418,7 +418,7 @@ describe.each([
     }).reply({status: 200, data: [{name: "project2-forked", owner: {login: "owner4"}}]});
 
     moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner1:sbranch2-forked", base: "tbranch1"}).reply({status: 200, data: [{title: "pr"}]});
-    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner4/project2-forked:sbranch2-forked", base: "tbranch2"}).reply({status: 200, data: [{title: "pr"}]});
+    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner4:sbranch2-forked", base: "tbranch2"}).reply({status: 200, data: [{title: "pr"}]});
 
     const checkedOutNodeInfo = await checkoutService.checkoutDefinitionTree();
 
@@ -490,7 +490,7 @@ describe.each([
     }).reply({status: 200, data: [{name: "project2-forked", owner: {login: "owner4"}}]});
 
     moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner1:sbranch2-forked", base: "tbranch1"}).reply({status: 200, data: []});
-    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner4/project2-forked:sbranch2-forked", base: "tbranch2"}).reply({status: 200, data: [{title: "pr"}]});
+    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner4:sbranch2-forked", base: "tbranch2"}).reply({status: 200, data: [{title: "pr"}]});
 
     
     const checkedOutNodeInfo = await checkoutService.checkoutDefinitionTree();
@@ -592,8 +592,8 @@ describe.each([
       repo: "project2"
     }).reply({status: 200, data: {}});
 
-    moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner2/project1-forked:tbranch2", base: "tbranch1"}).reply({status: 200, data: [{title: "pr"}]});
-    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2/project2:tbranch2", base: "tbranch2"}).reply({status: 200, data: []});
+    moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner2:tbranch2", base: "tbranch1"}).reply({status: 200, data: [{title: "pr"}]});
+    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:tbranch2", base: "tbranch2"}).reply({status: 200, data: []});
     moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:tbranch2", base: "tbranch2"}).reply({status: 200, data: []});
  
     const checkedOutNodeInfo = await checkoutService.checkoutDefinitionTree();
@@ -664,7 +664,7 @@ describe.each([
     }).reply({status: 200, data: {}});
 
     moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner1:tbranch2", base: "tbranch1"}).reply({status: 200, data: [{title: "pr"}]});
-    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2/project2:tbranch2", base: "tbranch2"}).reply({status: 200, data: []});
+    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:tbranch2", base: "tbranch2"}).reply({status: 200, data: []});
     moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:tbranch2", base: "tbranch2"}).reply({status: 200, data: []});
  
     const checkedOutNodeInfo = await checkoutService.checkoutDefinitionTree();
@@ -735,7 +735,7 @@ describe.each([
     }).reply({status: 200, data: {}});
 
     moctokit.rest.pulls.list({owner: "owner1", repo: "project1", state: "open", head: "owner1:tbranch2", base: "tbranch1"}).reply({status: 200, data: []});
-    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2/project2:tbranch2", base: "tbranch2"}).reply({status: 200, data: []});
+    moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:tbranch2", base: "tbranch2"}).reply({status: 200, data: []});
     moctokit.rest.pulls.list({owner: "owner2", repo: "project2", state: "open", head: "owner2:tbranch2", base: "tbranch2"}).reply({status: 200, data: []});
  
     


### PR DESCRIPTION
In octokit/rest 18 doc (https://octokit.github.io/rest.js/v18) there is explanation about octokit.rest.pulls.list and for the `head` field it mentions:

`Filter pulls by head user or head organization and branch name in the format of user:ref-name or organization:ref-name. For example: github:new-script-format or octocat:test-branch.`

We are currently using user/fork-name:ref-name and from the documentation it seems it should be user:ref-name