### PR TITLE
Update build-chain-configuration-reader to

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-action",
-      "version": "3.5.7",
+      "version": "3.5.8",
       "license": "ISC",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "description": "Library to execute commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",


### PR DESCRIPTION
There is a new release of build-chain-configuration-reader. Verify that there are no breaking changes