### PR TITLE
fix. 483, use node24 as default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
     description: "The prefix to identify the annotations for different jobs running for the same Action"
     required: false
 runs:
-  using: "node16"
+  using: "node24"
   main: "dist/index.js"
 branding:
   icon: "box"

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,6 +8,7 @@ const jestConfig: Config.InitialOptions = {
   moduleNameMapper: {
     "^@bc/(.*)$": "<rootDir>/src/$1",
   },
+  testPathIgnorePatterns: ["<rootDir>/build/"],
   clearMocks: true,
   resetMocks: true,
   coveragePathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/test/"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-action",
-  "version": "3.5.10",
+  "version": "3.6.0",
   "description": "Library to execute build commands based on github projects dependencies.",
   "main": "dist/index.js",
   "author": "",


### PR DESCRIPTION
**Thank you for submitting this pull request**

fix - closes #483 

> **_Note:_** Please, do not check `dist/index.js` changes. It is automatically generated.
